### PR TITLE
Added styling to the calendar

### DIFF
--- a/src/components/common/Calendar.js
+++ b/src/components/common/Calendar.js
@@ -1,5 +1,6 @@
 import { Calendar, Badge, Button } from 'antd';
 import React from 'react';
+import '../../styles/Calendar.css';
 
 function getListData(value) {
   let listData;
@@ -75,24 +76,3 @@ const CalendarFeature = () => {
   );
 };
 export default CalendarFeature;
-
-// CSS portion, will add colors and sizing later
-//   .events {
-//     margin: 0;
-//     padding: 0;
-//     list-style: none;
-//   }
-//   .events .ant-badge-status {
-//     width: 100%;
-//     overflow: hidden;
-//     font-size: 12px;
-//     white-space: nowrap;
-//     text-overflow: ellipsis;
-//   }
-//   .notes-month {
-//     font-size: 28px;
-//     text-align: center;
-//   }
-//   .notes-month section {
-//     font-size: 28px;
-//   }

--- a/src/components/pages/Navbar/Navbar.js
+++ b/src/components/pages/Navbar/Navbar.js
@@ -12,7 +12,7 @@ const Navbar = () => {
       </div>
       <div className="navBoxRight">
         <nav>
-          <Button type="link" className="navBarFont" href="/examplefeature">
+          <Button type="link" className="navBarFont" href="/Calendarfeature">
             Feature1
           </Button>
           <Button type="link" className="navBarFont" href="/examplefeature">

--- a/src/styles/Calendar.css
+++ b/src/styles/Calendar.css
@@ -1,0 +1,27 @@
+.calendar{
+    padding-right: 2.5%;
+    padding-left: 2.5%;
+    width: fit-content;
+    border: solid 4px;
+    border-color: grey;
+}
+.events {
+    margin: 0;
+    padding-right: 0;
+    list-style: none;
+}
+.events .ant-badge-status {
+    width: 100%;
+    overflow: hidden;
+    font-size: 12px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+.notes-month {
+    font-size: 28px;
+    text-align: left;
+}
+.notes-month section {
+    font-size: 28px;
+}
+  


### PR DESCRIPTION
## Description

Added styling to the calendar including a border. It still bleeds into the footer but the only change that needs to be made for that is changing `position: fixed;` and it will give the calendar space. I would have changed it but I know the footer is actively being worked on now.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes

https://user-images.githubusercontent.com/81526595/142479794-6a197d08-2b37-4e24-b05e-51fe8ebe93c0.mp4

