### PR TITLE
Bug/theme toggle

### DIFF
--- a/src/components/common/Sidebar/Sidebar.js
+++ b/src/components/common/Sidebar/Sidebar.js
@@ -10,7 +10,6 @@ import {
   DollarOutlined,
   BulbOutlined,
   CalendarOutlined,
-  ContainerOutlined,
   UserOutlined,
 } from '@ant-design/icons';
 

--- a/src/components/common/Sidebar/Sidebar.js
+++ b/src/components/common/Sidebar/Sidebar.js
@@ -1,4 +1,4 @@
-import React, { useState, useLayoutEffect } from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { useOktaAuth } from '@okta/okta-react';
 import 'antd/dist/antd.css';
@@ -34,7 +34,7 @@ const Sidebar = ({ authService, userProfile }) => {
   const [render, updateRender] = useState(1);
   const { authState } = useOktaAuth();
 
-  const toggleTheme = useTheme();
+  const [theme, toggleTheme] = useTheme();
 
   useEffect(() => {
     getAuthHeader(authState);
@@ -176,7 +176,12 @@ const Sidebar = ({ authService, userProfile }) => {
           <Menu.Item key="13" icon={<BulbOutlined />}>
             <div id="darkmode">
               Darkmode
-              <Toggle size="small" id="darkModeToggle" onClick={toggleTheme} />
+              <Toggle
+                size="small"
+                id="darkModeToggle"
+                onClick={toggleTheme}
+                checked={theme === 'dark' ? true : false}
+              />
             </div>
           </Menu.Item>
         </Menu>

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,5 +1,5 @@
 import useLocalStorage from './useLocalStorage';
-import { useEffect, useLayoutEffect } from 'react';
+import { useEffect } from 'react';
 
 const stylesheets = {
   light: 'https://cdnjs.cloudflare.com/ajax/libs/antd/4.9.4/antd.min.css',
@@ -20,16 +20,7 @@ export default function useTheme() {
   );
   const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');
 
-  useLayoutEffect(
-    function flipToggleBtn() {
-      const toggleBtn = document.getElementById('darkModeToggle');
-      theme === 'dark' && toggleBtn.classList.add('ant-switch-checked');
-      theme === 'light' && toggleBtn.classList.remove('ant-switch-checked');
-    },
-    [theme]
-  );
-
-  useLayoutEffect(() => {
+  useEffect(() => {
     setTheme(darkTheme ? 'dark' : 'light');
     document.head.querySelector('#antd-stylesheet') || createAntStylesheet();
   }, []); //eslint-disable-line
@@ -40,6 +31,5 @@ export default function useTheme() {
     },
     [theme]
   );
-
-  return toggleTheme;
+  return [theme, toggleTheme];
 }


### PR DESCRIPTION
## Description
The bug happens in the case where a user's computer theme is dark by default. On a successful login the Sidebar component mounts. The Darkmode toggle switch should be on... but it's off instead.
<img width="145" alt="Screen Shot 2022-02-25 at 11 49 57 AM" src="https://user-images.githubusercontent.com/32182282/155754588-6ccde043-ebb4-4c38-a18b-6fae3a06d846.png">

[veedeo](https://www.loom.com/share/a9346ebad50f4d6f9b5a3bb2b6aeec22)


**/common/Sidebar**
This PR fixes the bug by setting the `checked` property directly on the `Toggle` antd component rather than from within the theme hook via useLayoutEffect. Next I noticed the other useLayoutEffect didn't make any difference in functionality so I changed it to a useEffect. 

Originally when this hook was developed, the useLayoutEffect was the only way it worked. But when it was merged to main that was not the case. Hopefully this PR works!

Fixes # ([issue](https://trello.com/c/6GoCV6MU))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes