### PR TITLE
Removed extra 's' from /profile API calls

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -36,7 +36,7 @@ const getDSData = (url, authState) => {
 };
 
 const apiAuthGet = authHeader => {
-  return axios.get(`${apiUrl}profiles`, { headers: authHeader });
+  return axios.get(`${apiUrl}profile`, { headers: authHeader });
 };
 
 const getProfileData = authState => {

--- a/src/components/pages/Profile/RenderProfileContainer.js
+++ b/src/components/pages/Profile/RenderProfileContainer.js
@@ -21,7 +21,7 @@ const RenderProfileContainer = props => {
 
   useEffect(() => {
     axiosWithAuth()
-      .get(`/profiles/current_user_profile`)
+      .get(`/profile/current_user_profile`)
       .then(resp => {
         setUserData(resp.data);
       })

--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -50,7 +50,7 @@ const UserManagement = () => {
   useEffect(() => {
     const getAccounts = () => {
       axiosWithAuth()
-        .get('/profiles')
+        .get('/profile')
         .then(res => {
           setAccounts(
             res.data.map(row => ({

--- a/src/state/actions/userProfile/getProfile.js
+++ b/src/state/actions/userProfile/getProfile.js
@@ -8,7 +8,7 @@ import { setFetchEnd } from '../lifecycle/setFetchEnd';
 export const getProfile = profile_id => dispatch => {
   dispatch(setFetchStart());
   axiosWithAuth()
-    .get(`${API_URL}profiles/${profile_id}`)
+    .get(`${API_URL}profile/${profile_id}`)
     .then(res => {
       if (res.data) {
         dispatch(setUserProfile(res.data));

--- a/src/state/reducers/userReducer.js
+++ b/src/state/reducers/userReducer.js
@@ -8,7 +8,7 @@ const initialState = {
     profile_id: null,
   },
   userProfile: {
-    // when user hits dashboard, make API call to [GET] /profiles/:id
+    // when user hits dashboard, make API call to [GET] /profile/:id
     // first_name: 'Test',
     // last_name: 'Test',
     // role_id: 3,


### PR DESCRIPTION
## Description

Updated frontend API calls to reflect backend changes - instances of API calls using "/profiles" have been changed to "/profile"

Backend summary:
SUMMARY: The intention of this was to correct the router endpoints to follow best practices as per instructions here: https://medium.com/@mwaysolutions/10-best-practices-for-better-restful-api-cbe81b06f291
- the issue was that the endpoints to reach Profiles were both /profiles and /profile endpoint

#### Video Link

[Loom Video](https://loom.com/share/8d26125a843b40bda6b0b1073d848bc0)

#### Trello Link

[Trello Card](https://trello.com/c/ZmoJjjIz)
Bug: backend routes do not conform to REST API best practices i.e. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
