### PR TITLE
Scaffolded out the profile component to show the same values as the e…

### DIFF
--- a/src/components/pages/Profile/RenderProfileContainer.js
+++ b/src/components/pages/Profile/RenderProfileContainer.js
@@ -66,27 +66,21 @@ const RenderProfileContainer = props => {
             <Card type="inner" title="Bio" extra={<EditOutlined />}>
               {userData.bio || 'Profile bio will go here.'}
             </Card>
-
             <Card type="inner" title="Full Name" extra={<EditOutlined />}>
               {userData.full_name || 'Full Name will go here.'}
             </Card>
-
             <Card type="inner" title="Email" extra={<EditOutlined />}>
               {userData.email || 'Email will go here.'}
             </Card>
-
             <Card type="inner" title="Location" extra={<EditOutlined />}>
               {userData.location || 'Location will go here.'}
             </Card>
-
             <Card type="inner" title="Company" extra={<EditOutlined />}>
               {userData.company || 'Company/Position will go here.'}
             </Card>
-
             <Card type="inner" title="Commitment" extra={<EditOutlined />}>
               {'Commitment will go here.'}
             </Card>
-
             <Card
               style={{ marginTop: 16 }}
               type="inner"

--- a/src/components/pages/Profile/RenderProfileContainer.js
+++ b/src/components/pages/Profile/RenderProfileContainer.js
@@ -66,6 +66,27 @@ const RenderProfileContainer = props => {
             <Card type="inner" title="Bio" extra={<EditOutlined />}>
               {userData.bio || 'Profile bio will go here.'}
             </Card>
+
+            <Card type="inner" title="Full Name" extra={<EditOutlined />}>
+              {userData.full_name || 'Full Name will go here.'}
+            </Card>
+
+            <Card type="inner" title="Email" extra={<EditOutlined />}>
+              {userData.email || 'Email will go here.'}
+            </Card>
+
+            <Card type="inner" title="Location" extra={<EditOutlined />}>
+              {userData.location || 'Location will go here.'}
+            </Card>
+
+            <Card type="inner" title="Company" extra={<EditOutlined />}>
+              {userData.company || 'Company/Position will go here.'}
+            </Card>
+
+            <Card type="inner" title="Commitment" extra={<EditOutlined />}>
+              {'Commitment will go here.'}
+            </Card>
+
             <Card
               style={{ marginTop: 16 }}
               type="inner"

--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,8 @@ import Signup from './components/pages/RoleSignup/Signup';
 import Mentee from './components/pages/RoleSignup/Applications/Mentee';
 import Mentor from './components/pages/RoleSignup/Applications/Mentor';
 
-import AppError from './components/pages/RoleSignup/Applications/AppError';
+import AppSuccess from './components/pages/RoleSignup/Applications/AppSuccess';
 import ViewAllMeetings from './components/pages/ViewAllMeetings/ViewAllMeetings';
-
 
 import Navbar from './components/pages/Navbar/Navbar';
 import { ManageResources } from './components/pages/ManageResources/ManageResources';


### PR DESCRIPTION
## Description

After working on the Edit Profile modal we realized there was static information on the update profile page. Implemented the proper fields to go alongside the Edit profile modal. Simple scaffolding of that page to get it in line with the other components.

#### Video Link

[Loom Video] https://www.loom.com/share/26738496f43a4aa9a109f8f86c8fb2a0

#### Trello Link

https://trello.com/c/dPAK5bRb/295-as-a-user-i-want-to-see-the-my-profile-fields-on-the-edit-modal-rendered-on-the-my-profile-page

(Example below):


## Type of change

___Please delete options that are not relevant.___

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update


## Contributors

@BryceSlade 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
