### PR TITLE
navbar conditional rendering was backwards so that login/signup butto…

### DIFF
--- a/src/components/pages/Navbar/Navbar.js
+++ b/src/components/pages/Navbar/Navbar.js
@@ -110,7 +110,7 @@ const Navbar = ({ isAuthenticated, userProfile, getProfile }) => {
               </div>
             )}
 
-            {isAuthenticated && (
+            {!isAuthenticated && (
               <div className="header_buttons">
                 <LoginButton />
                 <SignupButton />


### PR DESCRIPTION
…ns were still visible after logging in

## Description

When I pulled down the latest code from repo, I noticed that the signup and login buttons on the navBar were persisting in staying visible even after being logged into the site. I checked the conditional rendering portion of the code handling the visibility conditions and found that it was missing the ! operator in the conditional statement. 

#### Video Link

[Loom Video](https://www.loom.com/share/372adc21f76748a2880d43225a36a544)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
