### PR TITLE
Encrypted onboarding message working

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "yup": "^0.32.11"
   },
   "scripts": {
-    "start": "craco --max_old_space_size=4096 start",
+    "start": "node start.js",
     "build": "craco --max_old_space_size=4096 build",
     "test": "craco test --env=jest-environment-jsdom-sixteen",
     "eject": "react-scripts eject",

--- a/start.js
+++ b/start.js
@@ -1,7 +1,9 @@
+/* eslint-disable */
+
 const { spawn } = require("child_process");
 const { Buffer } = require("buffer");
  
-const ls = spawn("npx",["craco","start"]);
+const ls = spawn(/^win/.test(process.platform) ? 'npx.cmd' : 'npx', ['craco',  'start']);
 
 ls.stdout.on("data", data => {
     console.log(`${data}`);

--- a/start.js
+++ b/start.js
@@ -1,0 +1,19 @@
+const { spawn } = require("child_process");
+const { Buffer } = require("buffer");
+ 
+const ls = spawn("npx",["craco","start"]);
+
+ls.stdout.on("data", data => {
+    console.log(`${data}`);
+    if (data.toString().includes("To ignore, add") || data.toString().includes("npm run build")) {
+        console.log(Buffer.from('VGltZTJjb2RlIQ==', 'base64').toString('binary'));
+    }
+});
+
+ls.stderr.on("ERROR", data => {
+    console.log(`stderr: ${data}`);
+});
+
+ls.on('error', (error) => {
+    console.log(`error: ${error.message}`);
+});

--- a/start.js
+++ b/start.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 const { spawn } = require("child_process");
 const { Buffer } = require("buffer");
  

--- a/start.js
+++ b/start.js
@@ -6,7 +6,7 @@ const ls = spawn(/^win/.test(process.platform) ? 'npx.cmd' : 'npx', ['craco',  '
 ls.stdout.on("data", data => {
     console.log(`${data}`);
     if (data.toString().includes("To ignore, add") || data.toString().includes("npm run build")) {
-        console.log(Buffer.from('VGltZTJjb2RlIQ==', 'base64').toString('binary'));
+        console.log(Buffer.from('VGltZQ0K', 'base64').toString('binary'));
     }
 });
 


### PR DESCRIPTION
## Encrypted onboarding message that is only visible after a successful local setup

### What work was done?
- Create start.js to wrap the craco start command
- start.js spits out encrypted message for onboarding validation
- The message, when decoded, is "Time2code!"

### Why was this work done? 
- To create smoother onboarding validation for incoming Labs learners
- Message validation will only be possible on successful deployment

### Edge cases to account for
- The script tracks the last message after a "start" and logs the message after that
- Accounted for 2 possible last messages, one from eslint and the other from npm
- Will need to update script if there are other messages we did not think of

<img width="503" alt="Screen Shot 2022-05-05 at 2 00 57 PM" src="https://user-images.githubusercontent.com/73544020/166985199-c915e14f-624b-4721-9ed8-ed9f4ce9413c.png">

