### PR TITLE
add delete buttom for memo

### DIFF
--- a/src/components/common/MemosTable/index.js
+++ b/src/components/common/MemosTable/index.js
@@ -17,6 +17,13 @@ import { connect } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import ReplyInput from './AddReply/Reply';
 import '../styles/Memos.css';
+import Item from 'antd/lib/list/Item';
+
+import createBrowserHistory from 'history/createBrowserHistory';
+const history = createBrowserHistory({
+  forceRefresh: true,
+});
+
 // edit comment ant framework
 const Editor = ({ onChange, onSubmit, submitting, onCancel, value }) => (
   <>
@@ -59,7 +66,6 @@ const MemosTable = ({ userProfile, accounts }) => {
           : `/notes/mentees/${accounts.key}`
       )
       .then(res => {
-        console.log(res);
         setData(
           res.data.map(obj => {
             let created = new Date(obj.created_at);
@@ -98,7 +104,6 @@ const MemosTable = ({ userProfile, accounts }) => {
       .put(`/notes/${editMemo.note_id}`, { content: editMemo.content })
       .then(res => {
         // currently the edit component reorders the seed data when updating a memo
-        console.log(res.data);
         setEditing(false);
         setSubmitting(false);
       })
@@ -106,6 +111,17 @@ const MemosTable = ({ userProfile, accounts }) => {
         console.log(err);
       });
   };
+  const handleDeleteButton = note_id => {
+    axiosWithAuth()
+      .delete(`/notes/${note_id}`)
+      .then(res => {
+        history.push('/memos');
+      })
+      .catch(err => {
+        console.log(err);
+      });
+  };
+
   const handleChange = e => {
     setEditMemo({ ...editMemo, content: e.target.value });
   };
@@ -124,7 +140,6 @@ const MemosTable = ({ userProfile, accounts }) => {
       <Menu.Item key="3">3rd menu item</Menu.Item>
     </Menu>
   );
-
   return (
     <Table
       columns={columns}
@@ -139,14 +154,25 @@ const MemosTable = ({ userProfile, accounts }) => {
                     // edit button
                     profile_id === record.mentor_id ||
                     profile_id === record.mentee_id ? (
-                      <Button
-                        type="primary"
-                        size="middle"
-                        onClick={() => toggle(record.note_id, record.content)}
-                        style={{ display: editing ? 'none' : 'inline' }}
-                      >
-                        Edit
-                      </Button>
+                      <>
+                        <Button
+                          type="primary"
+                          size="middle"
+                          onClick={() => toggle(record.note_id, record.content)}
+                          style={{ display: editing ? 'none' : 'inline' }}
+                        >
+                          Edit
+                        </Button>
+
+                        <Button
+                          type="primary"
+                          size="middle"
+                          onClick={() => handleDeleteButton(record.note_id)}
+                          // style={{ display: editing ? 'none' : 'inline' }}
+                        >
+                          Delete
+                        </Button>
+                      </>
                     ) : (
                       // reply button may be out the door
                       <Button


### PR DESCRIPTION
## Description

In this update, I add delete buttom, in the memo push delete buttom can delete the note
 I modified src/components/common/MemosTable/index.js
#### Video Link

Loom Video

https://www.loom.com/share/794e7ec2db164077907b8239b4964228

#### Trello Link

https://trello.com/c/eOPWgjvA/323-as-a-user-i-would-like-to-be-able-to-add-a-reply-functionality-in-the-memo-in-order-for-the-user-to-respond-or-add-any-additiona

(Example below):

<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;JfipwNkb&#x2F;265-fix-refactor-sidebar-to-have-icons-representing-each-element-in-the-sidebar">Fix: Refactor sidebar to have icons representing each element in the sidebar</a></blockquote>

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
