### PR TITLE
BL-272  added show password option inside password input area

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,28 +1,34 @@
 ## Description
 
-Updated LoginContainer where use can toggle password and see what they typed.
+___Add your PR description here, deleting this example___
 
 #### Video Link
 
-https://www.loom.com/share/fea1f29fbb6b478c853a666da0b0dfd9
+[Loom Video](Add your loom video link here)
 
-#### Trello Link
+#### Jira Link
 
-No trello card just saw there was no option to see the password and added it 🤷
+___Paste your Jira ticket link here, deleting this example___
+
+(Example below):
+
+[Jira Ticket Here](https://bloomtechlabs.atlassian.net/browse/BL-272?atlOrigin=eyJpIjoiNTA1OTkzYWYxNDc1NGZmN2JkZDg3MzNhYTcxODAyMGQiLCJwIjoiaiJ9)
 
 ## Type of change
 
 ___Please delete options that are not relevant.___
 
-- [x] New feature (non-breaking change which adds functionality)
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] This change requires a documentation update
 
 ## Checklist:
 
-- [x] My code follows the style guidelines of this project
-- [x] I have performed a self-review of my own code
-- [x] I have removed unnecessary comments/console logs from my code
-- [x] My changes generate no new warnings
-- [x] I have checked my code and corrected any misspellings
-- [x] No duplicate code left within changed files
-- [x] Size of pull request kept to a minimum
-- [x] Pull request description clearly describes changes made & motivations for said changes
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have removed unnecessary comments/console logs from my code
+- [ ] My changes generate no new warnings
+- [ ] I have checked my code and corrected any misspellings
+- [ ] No duplicate code left within changed files
+- [ ] Size of pull request kept to a minimum
+- [ ] Pull request description clearly describes changes made & motivations for said changes

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,34 +1,28 @@
 ## Description
 
-___Add your PR description here, deleting this example___
+Updated LoginContainer where use can toggle password and see what they typed.
 
 #### Video Link
 
-[Loom Video](Add your loom video link here)
+https://www.loom.com/share/fea1f29fbb6b478c853a666da0b0dfd9
 
 #### Trello Link
 
-___Paste your trello card link here, deleting this example___
-
-(Example below):
-
-<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;JfipwNkb&#x2F;265-fix-refactor-sidebar-to-have-icons-representing-each-element-in-the-sidebar">Fix: Refactor sidebar to have icons representing each element in the sidebar</a></blockquote>
+No trello card just saw there was no option to see the password and added it 🤷
 
 ## Type of change
 
 ___Please delete options that are not relevant.___
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] This change requires a documentation update
+- [x] New feature (non-breaking change which adds functionality)
 
 ## Checklist:
 
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have removed unnecessary comments/console logs from my code
-- [ ] My changes generate no new warnings
-- [ ] I have checked my code and corrected any misspellings
-- [ ] No duplicate code left within changed files
-- [ ] Size of pull request kept to a minimum
-- [ ] Pull request description clearly describes changes made & motivations for said changes
+- [x] My code follows the style guidelines of this project
+- [x] I have performed a self-review of my own code
+- [x] I have removed unnecessary comments/console logs from my code
+- [x] My changes generate no new warnings
+- [x] I have checked my code and corrected any misspellings
+- [x] No duplicate code left within changed files
+- [x] Size of pull request kept to a minimum
+- [x] Pull request description clearly describes changes made & motivations for said changes

--- a/src/components/pages/Login/LoginContainer.js
+++ b/src/components/pages/Login/LoginContainer.js
@@ -18,7 +18,7 @@ const LoginContainer = () => {
         },
         // there is more we can do to handle some errors here.
       },
-      features: { registration: true },
+      features: { registration: true, showPasswordToggleOnSignInPage: true },
       // turning this feature on allows your widget to use Okta for user registration
       logo: 'path-to-your-logo',
       // add your custom logo to your signing/register widget here.


### PR DESCRIPTION
## Description

Updated LoginContainer where use can toggle password and see what they typed.

#### Video Link

https://www.loom.com/share/fea1f29fbb6b478c853a666da0b0dfd9

#### Trello Link

No trello card just saw there was no option to see the password and added it 🤷

(Example below):

<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;JfipwNkb&#x2F;265-fix-refactor-sidebar-to-have-icons-representing-each-element-in-the-sidebar">Fix: Refactor sidebar to have icons representing each element in the sidebar</a></blockquote>

## Type of change

___Please delete options that are not relevant.___


- [X] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
