### PR TITLE
Patch/fix okta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "@ant-design/pro-table": "^2.62.7",
         "@auth0/auth0-react": "^1.10.1",
         "@craco/craco": "^6.0.0",
-        "@okta/okta-react": "^3.0.2",
-        "@okta/okta-signin-widget": "^4.1.2",
+        "@okta/okta-react": "^6.5.0",
+        "@okta/okta-signin-widget": "^6.4.2",
         "@reduxjs/toolkit": "^1.8.2",
         "antd": "^4.20.1",
         "axios": "^0.21.1",
@@ -1944,23 +1944,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
-      "dependencies": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "node_modules/@babel/polyfill/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true
-    },
     "node_modules/@babel/preset-env": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.18.2.tgz",
@@ -3492,64 +3475,162 @@
         "node": ">=10"
       }
     },
-    "node_modules/@okta/configuration-validation": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@okta/configuration-validation/-/configuration-validation-0.4.3.tgz",
-      "integrity": "sha512-dn/1EMGhwajQwV/jNIrj6zvYDdDpFIQnrdqRAww/SvzIz9cuPbw1vYBRpBYX2RQpPhJJuy6iZf0XB6yWVDUavw==",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
-    },
     "node_modules/@okta/okta-auth-js": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-3.2.6.tgz",
-      "integrity": "sha512-4N3XkaHUs2QbUR3ymg+PtoPAGluU3IkBK1kIfoYWeONXTyz0v/PpAKgHDe3RJkvRkDQzvAJDdT6VL29wIYE1ww==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-6.7.0.tgz",
+      "integrity": "sha512-DktQcRQp2DLx9KCGVBlexvxOcp/ZvnMvOcp7TknT9DiLp+k9Uksce8oqKo1d04ZjLvAqnQnhxrdBXN8OZkS7uw==",
+      "peer": true,
       "dependencies": {
-        "Base64": "0.3.0",
-        "cross-fetch": "^3.0.0",
-        "js-cookie": "2.2.0",
-        "node-cache": "^4.2.0",
+        "@babel/runtime": "^7.12.5",
+        "@babel/runtime-corejs3": "^7.17.0",
+        "@peculiar/webcrypto": "^1.4.0",
+        "atob": "^2.1.2",
+        "Base64": "1.1.0",
+        "broadcast-channel": "^4.13.0",
+        "btoa": "^1.2.1",
+        "core-js": "^3.6.5",
+        "cross-fetch": "^3.1.5",
+        "js-cookie": "^3.0.1",
+        "jsonpath-plus": "^6.0.1",
+        "node-cache": "^5.1.2",
+        "p-cancelable": "^2.0.0",
+        "text-encoding": "^0.7.0",
         "tiny-emitter": "1.1.0",
+        "webcrypto-shim": "^0.1.5",
         "xhr2": "0.1.3"
       },
       "engines": {
-        "node": ">=10.3"
+        "node": ">=11.0",
+        "yarn": "^1.7.0"
       }
     },
     "node_modules/@okta/okta-react": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@okta/okta-react/-/okta-react-3.0.11.tgz",
-      "integrity": "sha512-CYTF9vlujFSinbP0eq2/hu66vHNQrhmuxT7XOJHRJhS5Fvd55LJq2NeyNkIb3IJ9RgQD8YKkrX3nJ7B1DfrwIg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@okta/okta-react/-/okta-react-6.5.0.tgz",
+      "integrity": "sha512-hDt4dswFIPp/JVyrbgrwxM3J9QzqJrd5ml28FKh2BvPZSqowRnAg7xdbMiaP6omLbLiygbnnKvkdVrrtB+5n0g==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
-        "@okta/configuration-validation": "^0.4.1",
-        "@okta/okta-auth-js": "^3.2.6"
+        "compare-versions": "^4.1.2"
       },
       "engines": {
         "node": ">=10.3",
         "yarn": "^1.7.0"
       },
       "peerDependencies": {
+        "@okta/okta-auth-js": "^5.3.1 || ^6.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
         "react-router-dom": ">=5.1.0"
       }
     },
+    "node_modules/@okta/okta-react/node_modules/compare-versions": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.3.tgz",
+      "integrity": "sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg=="
+    },
     "node_modules/@okta/okta-signin-widget": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@okta/okta-signin-widget/-/okta-signin-widget-4.5.2.tgz",
-      "integrity": "sha512-Th5EQzEO02wQWcXPJZIdJ1GGxr90MrnnrRAfbx4eH3uOdow7nBEfhW2byzd1npVQhCNWKuTfRcjHaaYgZPPNEw==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/@okta/okta-signin-widget/-/okta-signin-widget-6.4.3.tgz",
+      "integrity": "sha512-bMx+OCskWk+Pz6fxxoMhcZleHqX+DrSzS2CNkwEEEwRYV0amfe12PI99kQ4s+VmXGa0Ctdwy6g5I6fPBKuDZKw==",
       "dependencies": {
-        "@babel/polyfill": "^7.10.1",
-        "@babel/runtime": "^7.10.3",
-        "cross-fetch": "^3.0.4",
-        "handlebars": "^4.5.3",
+        "@okta/okta-auth-js": "6.5.1",
+        "@sindresorhus/to-milliseconds": "^1.0.0",
+        "@types/backbone": "^1.4.15",
+        "@types/jquery": "^3.5.14",
+        "@types/jqueryui": "^1.12.16",
+        "@types/q": "^1.5.5",
+        "@types/selectize": "^0.12.35",
+        "@types/underscore": "^1.11.4",
+        "clipboard": "^1.5.16",
+        "cross-fetch": "^3.1.5",
+        "handlebars": "^4.7.7",
+        "parse-ms": "^2.0.0",
         "q": "1.4.1",
         "u2f-api-polyfill": "0.4.3",
-        "underscore": "1.8.3"
+        "underscore": "1.13.1"
       },
       "optionalDependencies": {
         "fsevents": "*"
+      }
+    },
+    "node_modules/@okta/okta-signin-widget/node_modules/@okta/okta-auth-js": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-6.5.1.tgz",
+      "integrity": "sha512-mBzg+EH1Ey7skxHiimSN/ZYraB3l8ZXZlBi8RXNmRLwPMbFlZkQoKrrQu357S5YSEckF59Lqbb/r9Y3cXBNQBQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@babel/runtime-corejs3": "^7.17.0",
+        "@peculiar/webcrypto": "1.1.6",
+        "atob": "^2.1.2",
+        "Base64": "1.1.0",
+        "broadcast-channel": "^4.10.0",
+        "btoa": "^1.2.1",
+        "core-js": "^3.6.5",
+        "cross-fetch": "^3.1.5",
+        "js-cookie": "^3.0.1",
+        "jsonpath-plus": "^6.0.1",
+        "node-cache": "^5.1.2",
+        "p-cancelable": "^2.0.0",
+        "text-encoding": "^0.7.0",
+        "tiny-emitter": "1.1.0",
+        "webcrypto-shim": "^0.1.5",
+        "xhr2": "0.1.3"
+      },
+      "engines": {
+        "node": ">=11.0",
+        "yarn": "^1.7.0"
+      }
+    },
+    "node_modules/@okta/okta-signin-widget/node_modules/@peculiar/webcrypto": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.1.6.tgz",
+      "integrity": "sha512-xcTjouis4Y117mcsJslWAGypwhxtXslkVdRp7e3tHwtuw0/xCp1te8RuMMv/ia5TsvxomcyX/T+qTbRZGLLvyA==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.0.27",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.1.2",
+        "tslib": "^2.1.0",
+        "webcrypto-core": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.1.9.tgz",
+      "integrity": "sha512-Ipio+pXGpL/Vb0qB4GnOgFMgc1RAhKHOVy24rQYLvmOAVp9z/aFb+VdIiQH09NjgvGVmaWOUqSWd9vRHk3xbrg==",
+      "dependencies": {
+        "asn1js": "^3.0.4",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz",
+      "integrity": "sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.1.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0",
+        "webcrypto-core": "^1.7.4"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
     "node_modules/@plotly/d3-sankey": {
@@ -3685,6 +3766,14 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz",
       "integrity": "sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==",
       "dev": true
+    },
+    "node_modules/@sindresorhus/to-milliseconds": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/to-milliseconds/-/to-milliseconds-1.2.0.tgz",
+      "integrity": "sha512-nHpLEF6oRZJZ0ym8hmxz4jeSdnOqwWd5GC75GNQqNjfSG1IY55RE3AaGEC/QUDElLTuaPSBVa1rnV/C/rUkAUw==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -4143,6 +4232,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/backbone": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@types/backbone/-/backbone-1.4.15.tgz",
+      "integrity": "sha512-WWeKtYlsIMtDyLbbhkb96taJMEbfQBnuz7yw1u0pkphCOtksemoWhIXhK74VRCY9hbjnsH3rsJu2uUiFtnsEYg==",
+      "dependencies": {
+        "@types/jquery": "*",
+        "@types/underscore": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -4254,6 +4352,22 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/@types/jquery": {
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
+      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
+    "node_modules/@types/jqueryui": {
+      "version": "1.12.16",
+      "resolved": "https://registry.npmjs.org/@types/jqueryui/-/jqueryui-1.12.16.tgz",
+      "integrity": "sha512-6huAQDpNlso9ayaUT9amBOA3kj02OCeUWs+UvDmbaJmwkHSg/HLsQOoap/D5uveN9ePwl72N45Bl+Frp5xyG1Q==",
+      "dependencies": {
+        "@types/jquery": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -4347,6 +4461,16 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
+    "node_modules/@types/selectize": {
+      "version": "0.12.35",
+      "resolved": "https://registry.npmjs.org/@types/selectize/-/selectize-0.12.35.tgz",
+      "integrity": "sha512-OtutSd9mfyl2qjxNABguUGhwRmHcJRYqRNQEUVBC6QIw0P0DKbhsAF5RUhid1L0GdYGNef8l73kSB1KVpazXqA=="
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+    },
     "node_modules/@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -4379,6 +4503,11 @@
       "dependencies": {
         "source-map": "^0.6.1"
       }
+    },
+    "node_modules/@types/underscore": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.4.tgz",
+      "integrity": "sha512-uO4CD2ELOjw8tasUrAhvnn2W4A0ZECOvMjCivJr4gA9pGgjv+qxKWY9GLTMVEK8ej85BxQOocUyE7hImmSQYcg=="
     },
     "node_modules/@types/webpack": {
       "version": "4.41.32",
@@ -5354,6 +5483,19 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dependencies": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assert": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
@@ -5939,9 +6081,9 @@
       }
     },
     "node_modules/Base64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.3.0.tgz",
-      "integrity": "sha512-Jh2d5xGmLyzrzYpt2xdEiiAMbiCudzIGgDAeOqpg7f8nREA2DIjMDOp8k+PS2ELbrs2FvX5gyYRXYniZ6TkthA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-1.1.0.tgz",
+      "integrity": "sha512-qeacf8dvGpf+XAT27ESHMh7z84uRzj/ua2pQdJg483m3bEXv/kVFtDnMgvf70BQGqzbZhR9t6BmASzKvqfJf3Q=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -6164,6 +6306,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/broadcast-channel": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.13.0.tgz",
+      "integrity": "sha512-fcDr8QNJ4SOb6jyjUNZatVNmcHtSWfW4PFcs4xIEFZAtorKCIFoEYtjIjaQ4c0jrbr/Bl8NIwOWiLSyspoAnEQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "detect-node": "^2.1.0",
+        "microtime": "3.0.0",
+        "oblivious-set": "1.1.1",
+        "p-queue": "6.6.2",
+        "rimraf": "3.0.2",
+        "unload": "2.3.1"
+      }
+    },
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -6306,6 +6462,17 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/buffer": {
@@ -6903,6 +7070,21 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
+    },
+    "node_modules/clipboard": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
+      "integrity": "sha512-smkaRaIQsrnKN1F3wd1/vY9Q+DeR4L8ZCXKeHCFC2j8RZuSBbuImcLdnIO4GTxmzJxQuDGNKkyfpGoPW7Ua5bQ==",
+      "dependencies": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
+    "node_modules/clipboard/node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "node_modules/cliui": {
       "version": "5.0.0",
@@ -8662,6 +8844,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -12324,6 +12511,14 @@
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+      "dependencies": {
+        "delegate": "^3.1.2"
       }
     },
     "node_modules/graceful-fs": {
@@ -16690,9 +16885,12 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
-      "integrity": "sha512-7YAJP/LPE/MhDjHIdfIiT665HUSumCwPN2hAmO6OJZ8V3o1mtz2HeQ8BKetEjkh+3nqGxYaq1vPMViUR8kaOXw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -16820,6 +17018,14 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
+      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -17670,6 +17876,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/microtime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/microtime/-/microtime-3.0.0.tgz",
+      "integrity": "sha512-SirJr7ZL4ow2iWcb54bekS4aWyBQNVcEDBiwAz9D/sTgY59A+uE8UJU15cp5wyZmPBwg/3zf8lyCJ5NUe1nVlQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^1.2.0",
+        "node-gyp-build": "^3.8.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -18262,16 +18481,20 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
+    },
     "node_modules/node-cache": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
-      "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
       "dependencies": {
-        "clone": "2.x",
-        "lodash": "^4.17.15"
+        "clone": "2.x"
       },
       "engines": {
-        "node": ">= 0.4.6"
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/node-fetch": {
@@ -18318,6 +18541,16 @@
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -18732,6 +18965,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oblivious-set": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
+      "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w=="
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -18877,6 +19115,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-each-series": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
@@ -18939,6 +19185,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-retry": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
@@ -18948,6 +19209,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -19036,6 +19308,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/parse-node-version": {
@@ -22185,6 +22465,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/pxls": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.2.tgz",
@@ -25279,6 +25575,11 @@
         "compute-scroll-into-view": "^1.0.17"
       }
     },
+    "node_modules/select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA=="
+    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -27262,6 +27563,12 @@
         "vectorize-text": "^3.2.1"
       }
     },
+    "node_modules/text-encoding": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
+      "deprecated": "no longer maintained"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -27818,9 +28125,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "node_modules/unfetch": {
       "version": "4.2.0",
@@ -27933,6 +28240,15 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unload": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.3.1.tgz",
+      "integrity": "sha512-MUZEiDqvAN9AIDRbbBnVYVvfcR6DrjCqeU2YQMmliFZl9uaBUjTkhuDQkBiyAy8ad5bx1TXVbqZ3gg7namsWjA==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "2.1.0"
       }
     },
     "node_modules/unpipe": {
@@ -28813,6 +29129,23 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
       "integrity": "sha512-/wNyG+1FpiHhnfQo+TuA/XAUpvOOkKVl0A4qpT+oGcj5SlZCLmM+M1Py/3Sj8sy+YrEauCVITOxCsZKo6sPbQg=="
+    },
+    "node_modules/webcrypto-core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.5.tgz",
+      "integrity": "sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.1.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/webcrypto-shim": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
+      "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
     },
     "node_modules/webgl-context": {
       "version": "2.2.0",
@@ -31656,22 +31989,6 @@
         "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        }
-      }
-    },
     "@babel/preset-env": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.18.2.tgz",
@@ -32924,50 +33241,137 @@
         }
       }
     },
-    "@okta/configuration-validation": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@okta/configuration-validation/-/configuration-validation-0.4.3.tgz",
-      "integrity": "sha512-dn/1EMGhwajQwV/jNIrj6zvYDdDpFIQnrdqRAww/SvzIz9cuPbw1vYBRpBYX2RQpPhJJuy6iZf0XB6yWVDUavw==",
-      "requires": {
-        "lodash": "^4.17.15"
-      }
-    },
     "@okta/okta-auth-js": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-3.2.6.tgz",
-      "integrity": "sha512-4N3XkaHUs2QbUR3ymg+PtoPAGluU3IkBK1kIfoYWeONXTyz0v/PpAKgHDe3RJkvRkDQzvAJDdT6VL29wIYE1ww==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-6.7.0.tgz",
+      "integrity": "sha512-DktQcRQp2DLx9KCGVBlexvxOcp/ZvnMvOcp7TknT9DiLp+k9Uksce8oqKo1d04ZjLvAqnQnhxrdBXN8OZkS7uw==",
+      "peer": true,
       "requires": {
-        "Base64": "0.3.0",
-        "cross-fetch": "^3.0.0",
-        "js-cookie": "2.2.0",
-        "node-cache": "^4.2.0",
+        "@babel/runtime": "^7.12.5",
+        "@babel/runtime-corejs3": "^7.17.0",
+        "@peculiar/webcrypto": "^1.4.0",
+        "atob": "^2.1.2",
+        "Base64": "1.1.0",
+        "broadcast-channel": "^4.13.0",
+        "btoa": "^1.2.1",
+        "core-js": "^3.6.5",
+        "cross-fetch": "^3.1.5",
+        "js-cookie": "^3.0.1",
+        "jsonpath-plus": "^6.0.1",
+        "node-cache": "^5.1.2",
+        "p-cancelable": "^2.0.0",
+        "text-encoding": "^0.7.0",
         "tiny-emitter": "1.1.0",
+        "webcrypto-shim": "^0.1.5",
         "xhr2": "0.1.3"
       }
     },
     "@okta/okta-react": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@okta/okta-react/-/okta-react-3.0.11.tgz",
-      "integrity": "sha512-CYTF9vlujFSinbP0eq2/hu66vHNQrhmuxT7XOJHRJhS5Fvd55LJq2NeyNkIb3IJ9RgQD8YKkrX3nJ7B1DfrwIg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@okta/okta-react/-/okta-react-6.5.0.tgz",
+      "integrity": "sha512-hDt4dswFIPp/JVyrbgrwxM3J9QzqJrd5ml28FKh2BvPZSqowRnAg7xdbMiaP6omLbLiygbnnKvkdVrrtB+5n0g==",
       "requires": {
         "@babel/runtime": "^7.11.2",
-        "@okta/configuration-validation": "^0.4.1",
-        "@okta/okta-auth-js": "^3.2.6"
+        "compare-versions": "^4.1.2"
+      },
+      "dependencies": {
+        "compare-versions": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.3.tgz",
+          "integrity": "sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg=="
+        }
       }
     },
     "@okta/okta-signin-widget": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@okta/okta-signin-widget/-/okta-signin-widget-4.5.2.tgz",
-      "integrity": "sha512-Th5EQzEO02wQWcXPJZIdJ1GGxr90MrnnrRAfbx4eH3uOdow7nBEfhW2byzd1npVQhCNWKuTfRcjHaaYgZPPNEw==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/@okta/okta-signin-widget/-/okta-signin-widget-6.4.3.tgz",
+      "integrity": "sha512-bMx+OCskWk+Pz6fxxoMhcZleHqX+DrSzS2CNkwEEEwRYV0amfe12PI99kQ4s+VmXGa0Ctdwy6g5I6fPBKuDZKw==",
       "requires": {
-        "@babel/polyfill": "^7.10.1",
-        "@babel/runtime": "^7.10.3",
-        "cross-fetch": "^3.0.4",
+        "@okta/okta-auth-js": "6.5.1",
+        "@sindresorhus/to-milliseconds": "^1.0.0",
+        "@types/backbone": "^1.4.15",
+        "@types/jquery": "^3.5.14",
+        "@types/jqueryui": "^1.12.16",
+        "@types/q": "^1.5.5",
+        "@types/selectize": "^0.12.35",
+        "@types/underscore": "^1.11.4",
+        "clipboard": "^1.5.16",
+        "cross-fetch": "^3.1.5",
         "fsevents": "*",
-        "handlebars": "^4.5.3",
+        "handlebars": "^4.7.7",
+        "parse-ms": "^2.0.0",
         "q": "1.4.1",
         "u2f-api-polyfill": "0.4.3",
-        "underscore": "1.8.3"
+        "underscore": "1.13.1"
+      },
+      "dependencies": {
+        "@okta/okta-auth-js": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-6.5.1.tgz",
+          "integrity": "sha512-mBzg+EH1Ey7skxHiimSN/ZYraB3l8ZXZlBi8RXNmRLwPMbFlZkQoKrrQu357S5YSEckF59Lqbb/r9Y3cXBNQBQ==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@babel/runtime-corejs3": "^7.17.0",
+            "@peculiar/webcrypto": "1.1.6",
+            "atob": "^2.1.2",
+            "Base64": "1.1.0",
+            "broadcast-channel": "^4.10.0",
+            "btoa": "^1.2.1",
+            "core-js": "^3.6.5",
+            "cross-fetch": "^3.1.5",
+            "js-cookie": "^3.0.1",
+            "jsonpath-plus": "^6.0.1",
+            "node-cache": "^5.1.2",
+            "p-cancelable": "^2.0.0",
+            "text-encoding": "^0.7.0",
+            "tiny-emitter": "1.1.0",
+            "webcrypto-shim": "^0.1.5",
+            "xhr2": "0.1.3"
+          }
+        },
+        "@peculiar/webcrypto": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.1.6.tgz",
+          "integrity": "sha512-xcTjouis4Y117mcsJslWAGypwhxtXslkVdRp7e3tHwtuw0/xCp1te8RuMMv/ia5TsvxomcyX/T+qTbRZGLLvyA==",
+          "requires": {
+            "@peculiar/asn1-schema": "^2.0.27",
+            "@peculiar/json-schema": "^1.1.12",
+            "pvtsutils": "^1.1.2",
+            "tslib": "^2.1.0",
+            "webcrypto-core": "^1.2.0"
+          }
+        }
+      }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.1.9.tgz",
+      "integrity": "sha512-Ipio+pXGpL/Vb0qB4GnOgFMgc1RAhKHOVy24rQYLvmOAVp9z/aFb+VdIiQH09NjgvGVmaWOUqSWd9vRHk3xbrg==",
+      "requires": {
+        "asn1js": "^3.0.4",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz",
+      "integrity": "sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==",
+      "peer": true,
+      "requires": {
+        "@peculiar/asn1-schema": "^2.1.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0",
+        "webcrypto-core": "^1.7.4"
       }
     },
     "@plotly/d3-sankey": {
@@ -33074,6 +33478,11 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz",
       "integrity": "sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==",
       "dev": true
+    },
+    "@sindresorhus/to-milliseconds": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/to-milliseconds/-/to-milliseconds-1.2.0.tgz",
+      "integrity": "sha512-nHpLEF6oRZJZ0ym8hmxz4jeSdnOqwWd5GC75GNQqNjfSG1IY55RE3AaGEC/QUDElLTuaPSBVa1rnV/C/rUkAUw=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -33389,6 +33798,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/backbone": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@types/backbone/-/backbone-1.4.15.tgz",
+      "integrity": "sha512-WWeKtYlsIMtDyLbbhkb96taJMEbfQBnuz7yw1u0pkphCOtksemoWhIXhK74VRCY9hbjnsH3rsJu2uUiFtnsEYg==",
+      "requires": {
+        "@types/jquery": "*",
+        "@types/underscore": "*"
+      }
+    },
     "@types/eslint": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -33493,6 +33911,22 @@
         }
       }
     },
+    "@types/jquery": {
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
+      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/jqueryui": {
+      "version": "1.12.16",
+      "resolved": "https://registry.npmjs.org/@types/jqueryui/-/jqueryui-1.12.16.tgz",
+      "integrity": "sha512-6huAQDpNlso9ayaUT9amBOA3kj02OCeUWs+UvDmbaJmwkHSg/HLsQOoap/D5uveN9ePwl72N45Bl+Frp5xyG1Q==",
+      "requires": {
+        "@types/jquery": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -33586,6 +34020,16 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
+    "@types/selectize": {
+      "version": "0.12.35",
+      "resolved": "https://registry.npmjs.org/@types/selectize/-/selectize-0.12.35.tgz",
+      "integrity": "sha512-OtutSd9mfyl2qjxNABguUGhwRmHcJRYqRNQEUVBC6QIw0P0DKbhsAF5RUhid1L0GdYGNef8l73kSB1KVpazXqA=="
+    },
+    "@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+    },
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -33618,6 +34062,11 @@
       "requires": {
         "source-map": "^0.6.1"
       }
+    },
+    "@types/underscore": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.4.tgz",
+      "integrity": "sha512-uO4CD2ELOjw8tasUrAhvnn2W4A0ZECOvMjCivJr4gA9pGgjv+qxKWY9GLTMVEK8ej85BxQOocUyE7hImmSQYcg=="
     },
     "@types/webpack": {
       "version": "4.41.32",
@@ -34379,6 +34828,16 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "requires": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
     "assert": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
@@ -34854,9 +35313,9 @@
       }
     },
     "Base64": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.3.0.tgz",
-      "integrity": "sha512-Jh2d5xGmLyzrzYpt2xdEiiAMbiCudzIGgDAeOqpg7f8nREA2DIjMDOp8k+PS2ELbrs2FvX5gyYRXYniZ6TkthA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-1.1.0.tgz",
+      "integrity": "sha512-qeacf8dvGpf+XAT27ESHMh7z84uRzj/ua2pQdJg483m3bEXv/kVFtDnMgvf70BQGqzbZhR9t6BmASzKvqfJf3Q=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -35045,6 +35504,20 @@
         "fill-range": "^7.0.1"
       }
     },
+    "broadcast-channel": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.13.0.tgz",
+      "integrity": "sha512-fcDr8QNJ4SOb6jyjUNZatVNmcHtSWfW4PFcs4xIEFZAtorKCIFoEYtjIjaQ4c0jrbr/Bl8NIwOWiLSyspoAnEQ==",
+      "requires": {
+        "@babel/runtime": "^7.16.0",
+        "detect-node": "^2.1.0",
+        "microtime": "3.0.0",
+        "oblivious-set": "1.1.1",
+        "p-queue": "6.6.2",
+        "rimraf": "3.0.2",
+        "unload": "2.3.1"
+      }
+    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -35172,6 +35645,11 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
+    },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
     "buffer": {
       "version": "4.9.2",
@@ -35642,6 +36120,23 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
+    },
+    "clipboard": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
+      "integrity": "sha512-smkaRaIQsrnKN1F3wd1/vY9Q+DeR4L8ZCXKeHCFC2j8RZuSBbuImcLdnIO4GTxmzJxQuDGNKkyfpGoPW7Ua5bQ==",
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      },
+      "dependencies": {
+        "tiny-emitter": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+          "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+        }
+      }
     },
     "cliui": {
       "version": "5.0.0",
@@ -37091,6 +37586,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "depd": {
       "version": "2.0.0",
@@ -40031,6 +40531,14 @@
             "supports-preserve-symlinks-flag": "^1.0.0"
           }
         }
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -43463,9 +43971,9 @@
       }
     },
     "js-cookie": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.0.tgz",
-      "integrity": "sha512-7YAJP/LPE/MhDjHIdfIiT665HUSumCwPN2hAmO6OJZ8V3o1mtz2HeQ8BKetEjkh+3nqGxYaq1vPMViUR8kaOXw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -43568,6 +44076,11 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
+    },
+    "jsonpath-plus": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
+      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw=="
     },
     "jsx-ast-utils": {
       "version": "3.3.1",
@@ -44257,6 +44770,15 @@
         "picomatch": "^2.3.1"
       }
     },
+    "microtime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/microtime/-/microtime-3.0.0.tgz",
+      "integrity": "sha512-SirJr7ZL4ow2iWcb54bekS4aWyBQNVcEDBiwAz9D/sTgY59A+uE8UJU15cp5wyZmPBwg/3zf8lyCJ5NUe1nVlQ==",
+      "requires": {
+        "node-addon-api": "^1.2.0",
+        "node-gyp-build": "^3.8.0"
+      }
+    },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -44754,13 +45276,17 @@
         "tslib": "^2.0.3"
       }
     },
+    "node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
+    },
     "node-cache": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
-      "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
       "requires": {
-        "clone": "2.x",
-        "lodash": "^4.17.15"
+        "clone": "2.x"
       }
     },
     "node-fetch": {
@@ -44796,6 +45322,11 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+    },
+    "node-gyp-build": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -45118,6 +45649,11 @@
         "es-abstract": "^1.19.1"
       }
     },
+    "oblivious-set": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
+      "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w=="
+    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -45229,6 +45765,11 @@
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true
     },
+    "p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
+    },
     "p-each-series": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
@@ -45264,12 +45805,29 @@
         "aggregate-error": "^3.0.0"
       }
     },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      }
+    },
     "p-retry": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
       "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
       "requires": {
         "retry": "^0.12.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -45344,6 +45902,11 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="
     },
     "parse-node-version": {
       "version": "1.0.1",
@@ -47870,6 +48433,19 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "pvtsutils": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
+    },
     "pxls": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.2.tgz",
@@ -50213,6 +50789,11 @@
         "compute-scroll-into-view": "^1.0.17"
       }
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA=="
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -51836,6 +52417,11 @@
         "vectorize-text": "^3.2.1"
       }
     },
+    "text-encoding": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -52292,9 +52878,9 @@
       }
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "unfetch": {
       "version": "4.2.0",
@@ -52386,6 +52972,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "unload": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.3.1.tgz",
+      "integrity": "sha512-MUZEiDqvAN9AIDRbbBnVYVvfcR6DrjCqeU2YQMmliFZl9uaBUjTkhuDQkBiyAy8ad5bx1TXVbqZ3gg7namsWjA==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "2.1.0"
+      }
     },
     "unpipe": {
       "version": "1.0.0",
@@ -53127,6 +53722,23 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
       "integrity": "sha512-/wNyG+1FpiHhnfQo+TuA/XAUpvOOkKVl0A4qpT+oGcj5SlZCLmM+M1Py/3Sj8sy+YrEauCVITOxCsZKo6sPbQg=="
+    },
+    "webcrypto-core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.5.tgz",
+      "integrity": "sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.1.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "webcrypto-shim": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
+      "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
     },
     "webgl-context": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "@ant-design/pro-table": "^2.62.7",
     "@auth0/auth0-react": "^1.10.1",
     "@craco/craco": "^6.0.0",
-    "@okta/okta-react": "^3.0.2",
-    "@okta/okta-signin-widget": "^4.1.2",
+    "@okta/okta-react": "^6.5.0",
+    "@okta/okta-signin-widget": "^6.4.2",
     "@reduxjs/toolkit": "^1.8.2",
     "antd": "^4.20.1",
     "axios": "^0.21.1",
@@ -96,5 +96,4 @@
     "react-error-overlay": "6.0.9",
     "yaml": "^1.10.0"
   }
-  
 }

--- a/src/components/common/PrivateRoute.js
+++ b/src/components/common/PrivateRoute.js
@@ -19,24 +19,26 @@ const PrivateRoute = ({
   ...rest
 }) => {
   const { push } = useHistory();
-  const { authState, authService } = useOktaAuth();
+  const { authState, oktaAuth } = useOktaAuth();
   const [loading, setLoading] = useState(true); // hiding contents
 
   useEffect(() => {
     if (Object.keys(userProfile).length === 0) {
       if (profile_id === null) {
-        if (authState.isPending || authState.isAuthenticated) {
-          dispatch(authenticateUser(authState, authService));
+        if (authState !== null) {
+          if (authState.isAuthenticated !== false) {
+            dispatch(authenticateUser(authState, oktaAuth));
+          } else {
+            push(redirect);
+          }
         } else {
-          push(redirect);
+          dispatch(getProfile(profile_id));
         }
+      } else if (allowRoles.includes(userProfile.role_id)) {
+        setLoading(false);
       } else {
-        dispatch(getProfile(profile_id));
+        push(redirect);
       }
-    } else if (allowRoles.includes(userProfile.role_id)) {
-      setLoading(false);
-    } else {
-      push(redirect);
     }
   }, [
     isAuthenticated,
@@ -45,7 +47,7 @@ const PrivateRoute = ({
     allowRoles,
     redirect,
     dispatch,
-    authService,
+    oktaAuth,
     authState,
     push,
   ]);

--- a/src/components/common/PrivateRoute.js
+++ b/src/components/common/PrivateRoute.js
@@ -25,20 +25,18 @@ const PrivateRoute = ({
   useEffect(() => {
     if (Object.keys(userProfile).length === 0) {
       if (profile_id === null) {
-        if (authState !== null) {
-          if (authState.isAuthenticated !== false) {
-            dispatch(authenticateUser(authState, oktaAuth));
-          } else {
-            push(redirect);
-          }
+        if (authState !== null && authState.isAuthenticated) {
+          dispatch(authenticateUser(authState, oktaAuth));
         } else {
-          dispatch(getProfile(profile_id));
+          push(redirect);
         }
-      } else if (allowRoles.includes(userProfile.role_id)) {
-        setLoading(false);
       } else {
-        push(redirect);
+        dispatch(getProfile(profile_id));
       }
+    } else if (allowRoles.includes(userProfile.role_id)) {
+      setLoading(false);
+    } else {
+      push(redirect);
     }
   }, [
     isAuthenticated,

--- a/src/components/pages/Login/LoginContainer.js
+++ b/src/components/pages/Login/LoginContainer.js
@@ -1,27 +1,28 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
+import { useHistory } from 'react-router-dom';
 import OktaSignIn from '@okta/okta-signin-widget';
 import '@okta/okta-signin-widget/dist/css/okta-sign-in.min.css';
 
 import { config } from '../../../utils/oktaConfig';
 
 const LoginContainer = () => {
-  useEffect(() => {
+  const history = useHistory();
+  const loadWidget = useCallback(() => {
     const { pkce, issuer, clientId, redirectUri, scopes } = config;
     // destructure your config so that you can pass it into the required fields in your widget.
     const widget = new OktaSignIn({
       baseUrl: issuer ? issuer.split('/oauth2')[0] : '',
+      el: '#sign-in-widget',
       clientId,
       redirectUri,
       registration: {
         click: function () {
-          window.location.href = '/apply';
+          history.push('apply');
         },
         // there is more we can do to handle some errors here.
       },
       features: { registration: true, showPasswordToggleOnSignInPage: true },
       // turning this feature on allows your widget to use Okta for user registration
-      logo: 'path-to-your-logo',
-      // add your custom logo to your signing/register widget here.
       i18n: {
         en: {
           'primaryauth.title': 'Welcome to Underdog Devs Please sign in',
@@ -37,19 +38,12 @@ const LoginContainer = () => {
       },
     });
 
-    widget.renderEl(
-      { el: '#sign-in-widget' },
-      () => {
-        /**
-         * In this flow, the success handler will not be called because we redirect
-         * to the Okta org for the authentication workflow.
-         */
-      },
-      err => {
-        throw err;
-      }
-    );
-  }, []);
+    widget.showSignInAndRedirect({}).catch(function (error) {});
+  }, [history]);
+
+  useEffect(() => {
+    loadWidget();
+  }, [loadWidget]);
 
   return <div id="sign-in-widget" />;
 };

--- a/src/components/pages/Navbar/Navbar.js
+++ b/src/components/pages/Navbar/Navbar.js
@@ -19,7 +19,7 @@ const { Header } = Layout;
 const Navbar = ({ isAuthenticated, userProfile, getProfile }) => {
   const [profilePic] = useState('https://joeschmoe.io/api/v1/random');
   const [user, setUser] = useState({});
-  const { authService } = useOktaAuth();
+  const { oktaAuth } = useOktaAuth();
   const [modal, setModal] = useState(false);
   const { push } = useHistory();
   const openModal = () => setModal(true);
@@ -29,7 +29,7 @@ const Navbar = ({ isAuthenticated, userProfile, getProfile }) => {
     setModal(false);
     localStorage.removeItem('role_id');
     localStorage.removeItem('token');
-    authService.logout();
+    oktaAuth.logout();
   };
   useEffect(() => {
     axiosWithAuth()

--- a/src/components/pages/Navbar/Navbar.js
+++ b/src/components/pages/Navbar/Navbar.js
@@ -29,7 +29,7 @@ const Navbar = ({ isAuthenticated, userProfile, getProfile }) => {
     setModal(false);
     localStorage.removeItem('role_id');
     localStorage.removeItem('token');
-    oktaAuth.logout();
+    oktaAuth.signOut();
   };
   useEffect(() => {
     axiosWithAuth()

--- a/src/components/pages/PendingApproval/PendingApproval.js
+++ b/src/components/pages/PendingApproval/PendingApproval.js
@@ -20,7 +20,7 @@ const menuItems = [
 ];
 
 const PendingApproval = props => {
-  const { authService, userInfo } = props;
+  const { oktaAuth, userInfo } = props;
   const [collapsed, setCollapsed] = useState(false);
   const [toggleTheme] = useTheme();
 
@@ -29,7 +29,7 @@ const PendingApproval = props => {
   };
 
   const handleLogout = checked => {
-    authService.logout();
+    oktaAuth.logout();
     localStorage.removeItem('role_id');
   };
 

--- a/src/components/pages/PendingApproval/PendingApproval.js
+++ b/src/components/pages/PendingApproval/PendingApproval.js
@@ -29,7 +29,7 @@ const PendingApproval = props => {
   };
 
   const handleLogout = checked => {
-    oktaAuth.logout();
+    oktaAuth.signOut();
     localStorage.removeItem('role_id');
   };
 

--- a/src/state/actions/auth/authenticateUser.js
+++ b/src/state/actions/auth/authenticateUser.js
@@ -4,17 +4,17 @@ import { setFetchError } from '../errors/setFetchError';
 import { setProfileId } from './setProfileId';
 import { setIsAuthenticated } from './setIsAuthenticated';
 
-export const authenticateUser = (authState, authService) => dispatch => {
-  if (authState.isAuthenticated) {
+export const authenticateUser = (authState, oktaAuth) => dispatch => {
+  if (oktaAuth.isAuthenticated) {
     dispatch(setFetchStart());
-    authService
+    oktaAuth
       .getUser()
       .then(parsedJWT => {
         const profile_id = parsedJWT.sub; // sub = profile_id from Okta JWT
         dispatch(setProfileId(profile_id));
         dispatch(setIsAuthenticated(true));
 
-        localStorage.setItem('token', authState.idToken);
+        localStorage.setItem('token', authState.idToken.idToken);
       })
       .catch(error => {
         dispatch(setFetchError(error));


### PR DESCRIPTION
## Description

Okta seems to have updated the way their service serves apps using the old recommended setup with the OktaSignInWidget, causing a bug telling us there's already an instance of the widget active, and to call `widget.logout` first.

Looking into fixing this, and upgrading Okta to its most recent version, leads one down a rabbit hole where you are required to update any usage of their Security component, and any old methods using `oktaAuth -> authService`. (`AuthService` is now deprecated, its old functionality being bundled into `oktaAuth` itself.)

This PR updates us to the most recent version of Okta, updates our usage of their Security component, and swaps all logic relying on `authService` to Okta's new standards for a SPA using the `oktaSignInWidget`, returning our app to it's original functionality.

## Type of change

___Please delete options that are not relevant.___

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
