### PR TITLE
Bl 706 fe as mentor set my availability

### DIFF
--- a/src/components/common/Sidebar/Sidebar.js
+++ b/src/components/common/Sidebar/Sidebar.js
@@ -2,7 +2,7 @@
 All of the commented out code on this page is to remove the 'no-unused-vars' warnings in the console
 */
 import React, { useMemo } from 'react';
-import { Layout, Menu, Switch as Toggle } from 'antd';
+import { Layout, Menu } from 'antd';
 import 'antd/dist/antd.css';
 import { connect } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';

--- a/src/components/common/styles/Sidebar.css
+++ b/src/components/common/styles/Sidebar.css
@@ -4,9 +4,12 @@
   justify-content: space-between;
 }
 
-.ant-switch-checked {
+/* This switch style, which does not appear to be in use, was overriding
+styling in the navbar. It is left here in case styling does need to use this
+class, in which case a fix can be made. */
+/* .ant-switch-checked {
   background-color: #BFBFBF !important;
-}
+} */
 
 .hidden {
   display: none;

--- a/src/components/common/styles/Sidebar.css
+++ b/src/components/common/styles/Sidebar.css
@@ -4,13 +4,6 @@
   justify-content: space-between;
 }
 
-/* This switch style, which does not appear to be in use, was overriding
-styling in the navbar. It is left here in case styling does need to use this
-class, in which case a fix can be made. */
-/* .ant-switch-checked {
-  background-color: #BFBFBF !important;
-} */
-
 .hidden {
   display: none;
 }

--- a/src/components/pages/Navbar/Navbar.css
+++ b/src/components/pages/Navbar/Navbar.css
@@ -52,6 +52,9 @@
 }
 
 /* Mentor nav styles */
+#mentorSwitch {
+  background-color: #73d13d;
+}
 
 .mentorStatus {
   height: 100%;
@@ -61,10 +64,6 @@
   justify-content: right;
   align-items: center;
   margin-right: 1%;
-}
-
-.ant-switch-checked {
-  background-color: #73d13d !important;
 }
 
 .toggleText {

--- a/src/components/pages/Navbar/Navbar.css
+++ b/src/components/pages/Navbar/Navbar.css
@@ -51,7 +51,26 @@
   padding-right: 3vw;
 }
 
+/* Mentor nav styles */
 
+.mentorStatus {
+  height: 100%;
+  width: 18%;
+  margin-left: auto;
+  display: flex;
+  justify-content: right;
+  align-items: center;
+  margin-right: 1%;
+}
+
+.ant-switch-checked {
+  background-color: #73d13d !important;
+}
+
+.toggleText {
+  color: white;
+  margin-left: 3%;
+}
 
 @media (max-width: 750px) {
   .logoDiv {
@@ -65,7 +84,6 @@
     justify-content: space-evenly !important;
     width: 100%;
     font-size: 1em;
-
   }
   .memos {
     display: flex;
@@ -90,4 +108,4 @@
     display: flex !important;
     justify-content: space-evenly !important;
   }
-} 
+}

--- a/src/components/pages/Navbar/Navbar.js
+++ b/src/components/pages/Navbar/Navbar.js
@@ -21,7 +21,7 @@ const Navbar = ({ isAuthenticated, userProfile, getProfile }) => {
   const [profilePic] = useState('https://joeschmoe.io/api/v1/random');
   const [user, setUser] = useState({});
   const [modal, setModal] = useState(false);
-  const [toggleStatus, setToggleStatus] = useState();
+  const [toggleStatus, setToggleStatus] = useState(false);
   const { logout } = useAuth0();
 
   const openModal = () => setModal(true);

--- a/src/components/pages/Navbar/Navbar.js
+++ b/src/components/pages/Navbar/Navbar.js
@@ -103,7 +103,11 @@ const Navbar = ({ isAuthenticated, userProfile, getProfile }) => {
                 placement="bottom"
               >
                 <section className="mentorStatus">
-                  <Switch defaultChecked onChange={handleToggleChange} />
+                  <Switch
+                    defaultChecked
+                    onChange={handleToggleChange}
+                    id="mentorSwitch"
+                  />
                   <span className="toggleText">
                     {toggleStatus
                       ? 'Open to new mentees'

--- a/src/components/pages/Navbar/Navbar.js
+++ b/src/components/pages/Navbar/Navbar.js
@@ -5,13 +5,14 @@ import { connect } from 'react-redux';
 import './Navbar.css';
 import logo from '../Navbar/ud_logo2.png';
 import { UserOutlined, FormOutlined } from '@ant-design/icons';
-import { Dropdown, Layout, Menu, Modal } from 'antd';
+import { Dropdown, Layout, Menu, Modal, Popover, Switch } from 'antd';
 import NavBarLanding from '../NavBarLanding/NavBarLanding';
 import { Link, useHistory } from 'react-router-dom';
 import { getProfile } from '../../../state/actions/userProfile/getProfile';
 import LoginButton from './NavbarFeatures/LoginButton';
 import SignupButton from './NavbarFeatures/SignupButton';
 import LogoutButton from './NavbarFeatures/LogoutButton';
+import MentorPopover from './NavbarFeatures/MentorPopover';
 import { useAuth0 } from '@auth0/auth0-react';
 
 const { Header } = Layout;
@@ -20,6 +21,7 @@ const Navbar = ({ isAuthenticated, userProfile, getProfile }) => {
   const [profilePic] = useState('https://joeschmoe.io/api/v1/random');
   const [user, setUser] = useState({});
   const [modal, setModal] = useState(false);
+  const [toggleStatus, setToggleStatus] = useState(true);
   const { logout } = useAuth0();
 
   const openModal = () => setModal(true);
@@ -67,7 +69,12 @@ const Navbar = ({ isAuthenticated, userProfile, getProfile }) => {
     // push(menu.key);
   };
 
+  const handleToggleChange = checked => {
+    !checked ? setToggleStatus(false) : setToggleStatus(true);
+  };
+
   const accountMenu = <Menu items={menuItems} onClick={handleMenuClick} />;
+  const isMentor = user.role_id === 3;
 
   const reloadLogo = () => {
     isAuthenticated ? history.push('/') : document.location.reload();
@@ -87,7 +94,24 @@ const Navbar = ({ isAuthenticated, userProfile, getProfile }) => {
                 role="button"
               />
             </div>
-
+            {isMentor && (
+              <Popover
+                title={`Status: ${
+                  toggleStatus ? 'Accepting' : 'Not Accepting'
+                }`}
+                content={<MentorPopover />}
+                placement="bottom"
+              >
+                <section className="mentorStatus">
+                  <Switch defaultChecked onChange={handleToggleChange} />
+                  <span className="toggleText">
+                    {toggleStatus
+                      ? 'Open to new mentees'
+                      : 'Closed to new mentees'}
+                  </span>
+                </section>
+              </Popover>
+            )}
             {Object.keys(user).length && (
               <div className="userInfo-and-profilePic">
                 <Link

--- a/src/components/pages/Navbar/NavbarFeatures/MentorPopover.js
+++ b/src/components/pages/Navbar/NavbarFeatures/MentorPopover.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const MentorPopover = () => (
+  <>
+    <p>
+      Please indicate if you are <br />
+      available to take on new mentees. <br />
+      This is an important part of our matching <br />
+      process.
+    </p>
+  </>
+);
+export default MentorPopover;


### PR DESCRIPTION
# Mentor Status - Setting Availability

This PR **implements the design** as outlined in **BL 709**. To reiterate motivation, mentors need to be able to quickly set their status (for accepting new mentees) and have that visible. This change involved a new addition to _Mentor_ navbars that includes dynamic labeling.

More on the design can be found in this [documentation](https://github.com/BloomTech-Labs/underdog-devs-docs).

## API
- Mentor toggle reads availability status of the mentor on initial rendering for persistence
- Mentor toggle is able to adjust the `accepting_new_mentees` boolean
- There is a BE route that requires a change. `router.post('/availability/:profile_id'` in _profileRouter.js_. The issue will be opened up shortly.

Feature # (706)

## Loom Video

https://www.loom.com/share/9aad82f993b243cda78f0a79b161e8c7

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files