### PR TITLE
Updated import history to current syntax, removed unused history var

### DIFF
--- a/src/components/common/MemosTable/AddReply/Reply.js
+++ b/src/components/common/MemosTable/AddReply/Reply.js
@@ -4,7 +4,7 @@ import useAxiosWithAuth0 from '../../../../hooks/useAxiosWithAuth0';
 import './Reply.css';
 import { Button } from 'antd';
 
-import createBrowserHistory from 'history/createBrowserHistory';
+import { createBrowserHistory } from 'history';
 const history = createBrowserHistory({
   forceRefresh: true,
 });

--- a/src/components/common/MemosTable/AddReply/Reply.js
+++ b/src/components/common/MemosTable/AddReply/Reply.js
@@ -4,11 +4,6 @@ import useAxiosWithAuth0 from '../../../../hooks/useAxiosWithAuth0';
 import './Reply.css';
 import { Button } from 'antd';
 
-import { createBrowserHistory } from 'history';
-const history = createBrowserHistory({
-  forceRefresh: true,
-});
-
 function ReplyInput(props) {
   const { note_id } = props;
   const [formValues, setFormValues] = useState({ comment_text: '' });

--- a/src/components/common/MemosTable/index.js
+++ b/src/components/common/MemosTable/index.js
@@ -15,11 +15,10 @@ import { connect } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import ReplyInput from './AddReply/Reply';
 import '../styles/Memos.css';
-
 import ShowReply from './AddReply/showReply';
-
-import createBrowserHistory from 'history/createBrowserHistory';
+import { createBrowserHistory } from 'history';
 import useAxiosWithAuth0 from '../../../hooks/useAxiosWithAuth0';
+
 const history = createBrowserHistory({
   forceRefresh: true,
 });


### PR DESCRIPTION

## Description
Before the update we had a console warning to update the syntax for importing history into React. The import was updated correctly from the MemosTable.js and removed an unused  history import and variable from Reply.js.

Fixes # BL-1009

## Loom Video

https://www.loom.com/share/fcec2abede034218a5cccddf172f6b8d

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes

