### PR TITLE
BL-967-fe-navbar-could-stay-fixed-when-scrolling

### DIFF
--- a/src/components/pages/Navbar/Navbar.less
+++ b/src/components/pages/Navbar/Navbar.less
@@ -67,6 +67,11 @@
   margin-left: 3%;
 }
 
+.ant-layout {
+  position: sticky;
+  top: 0px;
+  z-index: 1;
+}
 @media (max-width: 750px) {
   .logoDiv {
     display: flex !important;


### PR DESCRIPTION
## Description

# Ticket BL-967-fe-navbar-could-stay-fixed-when-scrolling

The user story for the ticket was to make the header sticky so that when the user scrolls down he has access to it all the time. specially on smaller screens when the user has to do a lot of scrolling.

we achieved the objective by doing the following:

- Target the correct class for the entire element we want to make sticky.
- Apply the position property: sticky to it.
- we noticed that when scrolling some of the items show up above the header. so we modified the Z-index property to fix this issue.

#### Video Link

[Loom Video](https://www.loom.com/share/f74a08a275724ac799b586acf0698ccd) 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
