### PR TITLE
BL-1066-be-fe-authentication-and-authorization-hook-ups

### DIFF
--- a/src/auth/auth0ProviderWithHistory.js
+++ b/src/auth/auth0ProviderWithHistory.js
@@ -5,7 +5,7 @@ import { Auth0Provider } from '@auth0/auth0-react';
 const Auth0ProviderWithHistory = ({ children }) => {
   const domain = process.env.REACT_APP_AUTH0_DOMAIN;
   const clientId = process.env.REACT_APP_AUTH0_CLIENT_ID;
-
+  const audience = process.env.REACT_APP_AUTH0_AUDIENCE;
   const history = useHistory();
 
   const onRedirectCallback = appState => {
@@ -19,6 +19,7 @@ const Auth0ProviderWithHistory = ({ children }) => {
       redirectUri={window.location.origin}
       onRedirectCallback={onRedirectCallback}
       cacheLocation="localstorage"
+      audience={audience}
     >
       {children}
     </Auth0Provider>

--- a/src/components/common/MemosTable/AddReply/Reply.js
+++ b/src/components/common/MemosTable/AddReply/Reply.js
@@ -8,7 +8,7 @@ function ReplyInput(props) {
   const { note_id } = props;
   const [formValues, setFormValues] = useState({ comment_text: '' });
   // const [comments, setComments] = useState({ comment_text: '' });
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   const { setComments, comments } = props;
   const handleChange = e => {
@@ -19,7 +19,7 @@ function ReplyInput(props) {
   };
 
   const handleSumbitButton = () => {
-    axiosWithAuth()
+    axiosWithAuth
       .post(`/notes/${note_id}/comments`, formValues)
       .then(res => {
         props.setTrigger(false);

--- a/src/components/common/MemosTable/AddReply/showReply.js
+++ b/src/components/common/MemosTable/AddReply/showReply.js
@@ -5,16 +5,14 @@ import moment from 'moment';
 
 function ShowReply(props) {
   const { note_id } = props;
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   const { setComments, comments } = props;
   useEffect(() => {
     const getComments = () => {
-      axiosWithAuth()
-        .get(`/notes/${note_id}/comments`)
-        .then(res => {
-          setComments(res.data);
-        });
+      axiosWithAuth.get(`/notes/${note_id}/comments`).then(res => {
+        setComments(res.data);
+      });
     };
     getComments();
   }, [note_id]);

--- a/src/components/common/MemosTable/index.js
+++ b/src/components/common/MemosTable/index.js
@@ -45,7 +45,7 @@ const Editor = ({ onChange, onSubmit, submitting, onCancel, value }) => (
 );
 
 const MemosTable = ({ userProfile, accounts }) => {
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
   const [data, setData] = useState([]);
   let result;
   // edit users own comment states
@@ -61,7 +61,7 @@ const MemosTable = ({ userProfile, accounts }) => {
 
   // Dummy data for table
   useEffect(() => {
-    axiosWithAuth()
+    axiosWithAuth
       .get(
         location.pathname === '/memos' || '/mymemos'
           ? '/notes'
@@ -102,7 +102,7 @@ const MemosTable = ({ userProfile, accounts }) => {
   };
   // dummy api update call, needs actual api endpoint to update
   const handleSaveButton = () => {
-    axiosWithAuth()
+    axiosWithAuth
       .put(`/notes/${editMemo.note_id}`, { content: editMemo.content })
       .then(res => {
         // currently the edit component reorders the seed data when updating a memo
@@ -114,7 +114,7 @@ const MemosTable = ({ userProfile, accounts }) => {
       });
   };
   const handleDeleteButton = note_id => {
-    axiosWithAuth()
+    axiosWithAuth
       .delete(`/notes/${note_id}`)
       .then(res => {
         history.push('/memos');

--- a/src/components/pages/Dashboard/Dashboard.js
+++ b/src/components/pages/Dashboard/Dashboard.js
@@ -11,10 +11,10 @@ import { Statistic, Row, Col, Table } from 'antd';
 
 const Dashboard = () => {
   const [role, setRole] = useState([]);
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   const getAccounts = () => {
-    axiosWithAuth()
+    axiosWithAuth
       .get('/profile/current_user_profile/')
       .then(res => {
         setRole(

--- a/src/components/pages/ManageResources/RenderResourceManagement.js
+++ b/src/components/pages/ManageResources/RenderResourceManagement.js
@@ -189,10 +189,10 @@ export const RenderResourceManagement = () => {
   const { formValues, handleChange, clearForm } = useForms(
     initialResourceFormValues
   );
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   useEffect(() => {
-    axiosWithAuth()
+    axiosWithAuth
       .get('/resources')
       .then(res => {
         setResources(res.data);

--- a/src/components/pages/Memos/MemosForm.js
+++ b/src/components/pages/Memos/MemosForm.js
@@ -35,10 +35,10 @@ const MemosForm = props => {
   const [toggle, setToggle] = useState(1);
   const [subjectType, setSubjectType] = useState(0);
   const [formValues, setFormValues] = useState(initialValues);
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   const postNewMemo = newMemo => {
-    axiosWithAuth()
+    axiosWithAuth
       .post('/notes', newMemo)
       .then(res => {
         push('/mymemos');

--- a/src/components/pages/MentorMenteeMatching/MentorMenteeMatching.js
+++ b/src/components/pages/MentorMenteeMatching/MentorMenteeMatching.js
@@ -7,15 +7,13 @@ const MentorMenteeMatching = () => {
   const [assignments, setAssignments] = useState([]);
   const [modal, setModal] = useState({ show: false, data: null });
   const [selectedMentorKeys, setSelectedMentorKeys] = useState([]);
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   useEffect(() => {
     // assignments in this sense means assigned mentees
-    axiosWithAuth()
-      .get('/assignments')
-      .then(res => {
-        setAssignments(conformData(res.data));
-      });
+    axiosWithAuth.get('/assignments').then(res => {
+      setAssignments(conformData(res.data));
+    });
   }, []);
 
   const resetModal = () => {

--- a/src/components/pages/Navbar/Navbar.js
+++ b/src/components/pages/Navbar/Navbar.js
@@ -21,7 +21,7 @@ const Navbar = ({ userProfile, getProfile, currentUser }) => {
   const [modal, setModal] = useState(false);
   const [toggleStatus, setToggleStatus] = useState(false);
   const { logout, isAuthenticated } = useAuth0();
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   const openModal = () => setModal(true);
   const cancelOpen = () => setModal(false);
@@ -38,15 +38,13 @@ const Navbar = ({ userProfile, getProfile, currentUser }) => {
   useEffect(() => {
     (async () => {
       if (isAuthenticated) {
-        const user = await axiosWithAuth().get(
-          `/profile/current_user_profile/`
-        );
+        const user = await axiosWithAuth.get(`/profile/current_user_profile/`);
 
         setUser(user.data);
 
         // The following code was taken from the userProfile redux action file
         setFetchStart();
-        axiosWithAuth()
+        axiosWithAuth
           .get(`${API_URL}profile/${user.data.profile_id}`)
           .then(res => {
             if (res.data) {
@@ -88,7 +86,7 @@ const Navbar = ({ userProfile, getProfile, currentUser }) => {
   };
 
   const handleToggleChange = checked => {
-    axiosWithAuth()
+    axiosWithAuth
       .post(`${API_URL}profile/availability/${profile_id}`, {
         accepting_new_mentees: checked,
       })

--- a/src/components/pages/PendingApplications/ApplicationModal.js
+++ b/src/components/pages/PendingApplications/ApplicationModal.js
@@ -24,7 +24,7 @@ const ApplicationModal = ({
 }) => {
   const [currentApplication, setCurrentApplication] = useState();
 
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   const dispatch = useDispatch();
 
@@ -93,7 +93,7 @@ const ApplicationModal = ({
    */
 
   const handleApplication = status => {
-    axiosWithAuth()
+    axiosWithAuth
       .post(`${API_URL}application/update-validate_status/${profileId}`, status)
       .then(res => {
         setDisplayModal(false);

--- a/src/components/pages/PendingApplications/PendingApplication.js
+++ b/src/components/pages/PendingApplications/PendingApplication.js
@@ -85,7 +85,7 @@ const PendingApplications = () => {
   const [applications, setApplications] = useState([]);
   const [modalIsVisible, setModalIsVisible] = useState(false);
   const [profileId, setProfileId] = useState('');
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   const showModal = profile_id => {
     setProfileId(profile_id);
@@ -94,7 +94,7 @@ const PendingApplications = () => {
 
   const getPendingApps = async () => {
     try {
-      const api = await axiosWithAuth().post(`/application`);
+      const api = await axiosWithAuth.post(`/application`);
       api.data.forEach(row => {
         row.hasOwnProperty('accepting_new_mentees')
           ? (row.role_name = 'mentor')

--- a/src/components/pages/Profile/EditProfile.js
+++ b/src/components/pages/Profile/EditProfile.js
@@ -7,7 +7,7 @@ import { setUserProfile } from '../../../state/actions/userProfile/setUserProfil
 
 function EditProfile({ userInfo, setUserProfile }) {
   const [form] = Form.useForm();
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   const [ModalOpen, setModalOpen] = useState(false);
 
@@ -17,7 +17,7 @@ function EditProfile({ userInfo, setUserProfile }) {
 
   const onCreate = values => {
     setModalOpen(false);
-    axiosWithAuth()
+    axiosWithAuth
       .put('/profile', values)
       .then(res => {
         form.setFieldsValue(values);

--- a/src/components/pages/Profile/RenderProfileContainer.js
+++ b/src/components/pages/Profile/RenderProfileContainer.js
@@ -18,10 +18,10 @@ const { Meta } = Card;
 
 const RenderProfileContainer = props => {
   const [userData, setUserData] = useState({});
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   useEffect(() => {
-    axiosWithAuth()
+    axiosWithAuth
       .get(`/profile/current_user_profile`)
       .then(resp => {
         setUserData(resp.data);

--- a/src/components/pages/Reviews/MentorReviews.js
+++ b/src/components/pages/Reviews/MentorReviews.js
@@ -6,11 +6,11 @@ const columns = [{ title: 'Mentor', dataIndex: 'name', key: 'name' }];
 
 const Reviews = () => {
   const [reviews, setReviews] = useState([]);
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   useEffect(() => {
     const getReviews = () => {
-      axiosWithAuth()
+      axiosWithAuth
         .get('/reviews')
         .then(res => {
           setReviews(

--- a/src/components/pages/TicketsDashboard/TicketsDashboard.js
+++ b/src/components/pages/TicketsDashboard/TicketsDashboard.js
@@ -64,17 +64,15 @@ const columns = [
 // TODO: make Ant Design Statistics pull ticket totals from ticket tables
 const TicketsDashboard = props => {
   const [tickets, setTickets] = useState([]);
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   useEffect(() => {
     const getTickets = () => {
-      axiosWithAuth()
-        .get('/resource-tickets')
-        .then(res => {
-          if (res.data.message === null) {
-            setTickets(res.data);
-          }
-        });
+      axiosWithAuth.get('/resource-tickets').then(res => {
+        if (res.data.message === null) {
+          setTickets(res.data);
+        }
+      });
     };
     getTickets();
   }, []);

--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -9,7 +9,7 @@ import { API_URL } from '../../../config';
 const UserManagement = () => {
   const [accounts, setAccounts] = useState([]);
   const [updatedProfile, setUpdatedProfile] = useState();
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   const dispatch = useDispatch();
 
@@ -66,7 +66,7 @@ const UserManagement = () => {
       role_id: 2,
     };
 
-    axiosWithAuth()
+    axiosWithAuth
       .put(`${API_URL}profile/${record.key}`, requestBody)
       .then(res => {
         setUpdatedProfile(res);

--- a/src/components/pages/ViewAllMeetings/ViewAllMeetings.js
+++ b/src/components/pages/ViewAllMeetings/ViewAllMeetings.js
@@ -4,7 +4,7 @@ import VAMC from './VAMC';
 
 const ViewAllMeetings = () => {
   const [meetingData, setMeetingData] = useState([]);
-  const { axiosWithAuth } = useAxiosWithAuth0();
+  const axiosWithAuth = useAxiosWithAuth0();
 
   const getDate = num => {
     let d = '';
@@ -31,7 +31,7 @@ const ViewAllMeetings = () => {
   };
 
   useEffect(() => {
-    axiosWithAuth()
+    axiosWithAuth
       .get('/meetings')
       .then(response => {
         setMeetingData(switchProp(response.data));

--- a/src/hooks/useAxiosWithAuth0.js
+++ b/src/hooks/useAxiosWithAuth0.js
@@ -9,6 +9,9 @@ const axios_instance = axios.create({
 const useAxiosWithAuth0 = () => {
   const { getAccessTokenSilently, isAuthenticated } = useAuth0();
 
+  // The implementaion of the axios interceptors used below can be found on axios docs on the
+  // following link: https://axios-http.com/docs/interceptors
+
   useEffect(() => {
     if (isAuthenticated) {
       axios_instance.interceptors.request.use(

--- a/src/hooks/useAxiosWithAuth0.js
+++ b/src/hooks/useAxiosWithAuth0.js
@@ -2,50 +2,29 @@ import { useEffect } from 'react';
 import axios from 'axios';
 import { useAuth0 } from '@auth0/auth0-react';
 
-/*
-NOTE:
-React requires that we can only call hooks in function components or within other hooks. As axiosWithAuth is simply a helper function we've built a useAxiosWithAuth0() hook in which we've called both axiosWithAuth AND useAuth0().
-axiosWithAuth serves the same function as it typically does. useAuth0() gives access to getAccessTokenSilently() for authentication/authorization purposes. 
-This hook below is exported and used throughout the app in place of axiosWithAuth.
-THIS useAxiosWithAuth0 HOOK SIMPLY SERVES TO HELP CONNECT THE AXIOS CALL AND THE AUTHENTICATION.
-*/
+const axios_instance = axios.create({
+  baseURL: process.env.REACT_APP_API_URI,
+});
 
-export default function useAxiosWithAuth0() {
-  const { getAccessTokenSilently } = useAuth0();
-
-  const axiosWithAuth = token => {
-    return axios.create({
-      baseURL: process.env.REACT_APP_API_URI,
-      headers: {
-        authorization: `Bearer ${token}`,
-      },
-    });
-  };
+const useAxiosWithAuth0 = () => {
+  const { getAccessTokenSilently, isAuthenticated } = useAuth0();
 
   useEffect(() => {
-    const locations = [
-      '/',
-      '/apply',
-      '/apply/mentee',
-      '/apply/mentor',
-      '/apply/success',
-    ];
+    if (isAuthenticated) {
+      axios_instance.interceptors.request.use(
+        async config => ({
+          ...config,
+          headers: {
+            ...config.headers,
+            Authorization: `Bearer ${await getAccessTokenSilently()}`,
+          },
+        }),
+        error => Promise.reject(error)
+      );
+    }
+  }, [getAccessTokenSilently, isAuthenticated]);
 
-    /********************************** */
+  return axios_instance;
+};
 
-    !locations.some(item => {
-      return item !== document.location.pathname;
-    }) &&
-      (async () => {
-        console.log(document.location);
-        const token = await getAccessTokenSilently();
-        axiosWithAuth(token);
-      })();
-    /********************************** */
-  }, [getAccessTokenSilently]);
-
-  return {
-    // Exported with the same name to reduce the amount of refactoring needed
-    axiosWithAuth,
-  };
-}
+export default useAxiosWithAuth0;


### PR DESCRIPTION
## Description

## Ticket BL-1066-be-fe-authentication-and-authorization-hook-ups

Intitially we had a BE middle-ware that was built to receive id_tokens, We needed to change it to receive an `accessToken` instead. 

The FE needed to get that token on demand and make sure that it's set on the `authorization header` on the request. That token was sometimes undefined.

Ticket objective is to wire FE API calls to BE private Endpoints through exchanging and verifying access_tokens by the auth. provider (auth0).


## Changes made to achieve the objective:

#### Back-End:

- Changed the audience in the .env file in order to verify access tokens instead of id tokens

#### Front-End:

- Added the audience in the .env file in order to add the add the correct header to the access token (jwt), to be verified later by the BE and the authProvider.
- Added the audience prop to the auth0Provider.
- Refactored the useAxiosWithAuth0 custom hook to create a new axios instance with the access token attached to the headers whenever we have authenticated user logged in.
- Fixed a bug in all private routes components that is supposed to consume the useAxiosWithAuth0 custom hook to add the access token to the request header when making api-call to private BE End-point.

### Video Link

[Loom Video](https://www.loom.com/share/9e12323c71734982b056eb55159f8f56)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
