### PR TITLE
Corrected ternary operator to display error message when appropriate

### DIFF
--- a/src/components/pages/RoleApply/Applications/Mentee.js
+++ b/src/components/pages/RoleApply/Applications/Mentee.js
@@ -476,7 +476,7 @@ const Mentee = ({ dispatch, error }) => {
                 }}
                 align="middle"
               >
-                {error ? (
+                {Object.keys(error).length !== 0 ? (
                   <p className="error">
                     We're sorry! Something went wrong. Please re-apply and try
                     again later.

--- a/src/components/pages/RoleApply/Applications/Mentor.js
+++ b/src/components/pages/RoleApply/Applications/Mentor.js
@@ -505,7 +505,7 @@ const Mentor = ({ dispatch, error }) => {
             }}
             align="middle"
           >
-            {error ? (
+            {Object.keys(error).length !== 0 ? (
               <p className="error">
                 We're sorry! Something went wrong. Please re-apply and try again
                 later.


### PR DESCRIPTION
## Description

When looking at either the mentee or mentor role application forms, the error message "We're sorry! Something went wrong. Please re-apply and try again later." is being constantly displayed.
​
### Fixes  (issue)

- After review, the error message was being perpetually displayed due to an incorrect implementation of a ternary operator within JSX.
- We updated the conditional statement to ensure that an error message is only displayed when the error object is not empty. 

![image](https://user-images.githubusercontent.com/104935405/208196481-9e463464-8bec-4738-b624-732199d77e6d.png)
​
## Loom Video

https://www.loom.com/share/b422a0659e32495ba8d2f35cf811c711

## Type of change
​
Please delete options that are not relevant.
​
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
​
## Checklist:
​
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes