### PR TITLE
fixes mentor form bug, tweaks CSS on mentor app page

### DIFF
--- a/src/components/pages/RoleApply/Applications/Mentor.js
+++ b/src/components/pages/RoleApply/Applications/Mentor.js
@@ -54,9 +54,8 @@ const initialFormValues = {
 };
 
 const Mentor = ({ dispatch, error }) => {
-  const { formValues, newMentor, handleChange, handleTechStack } = useForms(
-    initialFormValues
-  );
+  const { formValues, newMentor, handleChange, handleTechStack } =
+    useForms(initialFormValues);
   const { push } = useHistory();
 
   const formSubmit = () => {
@@ -318,7 +317,7 @@ const Mentor = ({ dispatch, error }) => {
 
             {/*CheckBoxes*/}
             <Row>
-              <Col className="mentorshipArea" md={12} xs={24}>
+              <Col md={12} xs={24}>
                 <Form.Item
                   size="medium"
                   className="form-group"
@@ -336,26 +335,27 @@ const Mentor = ({ dispatch, error }) => {
                       message: 'Tech stack is required.',
                     },
                   ]}
-                ></Form.Item>
-                <Checkbox.Group
-                  style={{
-                    display: 'flex',
-                    flexFlow: 'column',
-                    width: 'auto',
-                    gap: '.5rem',
-                    paddingLeft: '1rem',
-                  }}
                 >
-                  {mentorshipArray.map(checkbox => (
-                    <Checkbox
-                      value={checkbox.value}
-                      onChange={e => handleTechStack(e, 'checkbox')}
-                      style={{ margin: '.2rem', width: '100%' }}
-                    >
-                      {checkbox.value}
-                    </Checkbox>
-                  ))}
-                </Checkbox.Group>
+                  <Checkbox.Group
+                    style={{
+                      display: 'flex',
+                      flexFlow: 'column',
+                      width: 'auto',
+                      gap: '.5rem',
+                      paddingLeft: '1rem',
+                    }}
+                  >
+                    {mentorshipArray.map(checkbox => (
+                      <Checkbox
+                        value={checkbox.value}
+                        onChange={e => handleTechStack(e, 'checkbox')}
+                        style={{ margin: '.2rem', width: '100%' }}
+                      >
+                        {checkbox.value}
+                      </Checkbox>
+                    ))}
+                  </Checkbox.Group>
+                </Form.Item>
               </Col>
 
               <Col md={12} xs={24}>
@@ -376,26 +376,27 @@ const Mentor = ({ dispatch, error }) => {
                       message: 'Possible contribution is required.',
                     },
                   ]}
-                ></Form.Item>
-                <Checkbox.Group
-                  style={{
-                    display: 'flex',
-                    flexFlow: 'column',
-                    width: 'auto',
-                    gap: '.5rem',
-                    paddingLeft: '1rem',
-                  }}
                 >
-                  {contributionArray.map(area => (
-                    <Checkbox
-                      value={area.name}
-                      onChange={e => handleChange(e, 'checkbox')}
-                      style={{ margin: '.2rem', width: '100%' }}
-                    >
-                      {area.value}
-                    </Checkbox>
-                  ))}
-                </Checkbox.Group>
+                  <Checkbox.Group
+                    style={{
+                      display: 'flex',
+                      flexFlow: 'column',
+                      width: 'auto',
+                      gap: '.5rem',
+                      paddingLeft: '1rem',
+                    }}
+                  >
+                    {contributionArray.map(area => (
+                      <Checkbox
+                        value={area.name}
+                        onChange={e => handleChange(e, 'checkbox')}
+                        style={{ margin: '.2rem', width: '100%' }}
+                      >
+                        {area.value}
+                      </Checkbox>
+                    ))}
+                  </Checkbox.Group>
+                </Form.Item>
               </Col>
               <Divider />
               <Col md={24} xs={24}>

--- a/src/components/pages/RoleApply/Applications/Styles/mentorApplication.css
+++ b/src/components/pages/RoleApply/Applications/Styles/mentorApplication.css
@@ -39,6 +39,7 @@
 }
 .form-group {
   display: flex;
+  flex-direction: column;
   gap: 20px;
 }
 @media only screen and (max-width: 600px) {


### PR DESCRIPTION
## Description

This PR seeks to address an issue with the Mentor Application page, which has some broken error handling that results in the user being unable to submit the form, with the form telling them that two fields they have in fact filled out are required and missing information:

![image](https://user-images.githubusercontent.com/55460082/223230206-ec9af771-8712-4e94-8e30-6766110d3498.png)


This was due to the code for the checkboxes being mistakenly placed outside of the `Form.item` component that handles the validation for required fields, resulting in the form not “seeing” the user’s entered info.

Once this was fixed, a small change was made to the form's CSS to get the checkboxes to sit neatly under their prompt: (`display: flex;`) -> (`display: flex; flex-direction: column;`)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
