### PR TITLE
UD-296 Add toggle to user type to include mentees in view

### DIFF
--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { getAllUsers } from '../../../state/actions/allUsers/getAllUsers';
 import { useDispatch, connect } from 'react-redux';
-import { Table, Button, Switch, Tabs } from 'antd';
+import { Table, Button, Tabs } from 'antd';
 import UserModal from './UserModal';
 import MatchingModal from '../MentorMenteeMatching/MatchingModal';
 
@@ -9,7 +9,7 @@ const UserManagement = ({ allMentors, allMentees }) => {
   const [userShow, setUserShow] = useState(false);
   const [matchShow, setMatchShow] = useState(false);
   const [user, setUser] = useState('');
-  const [displayRole, setDisplayRole] = useState('Mentors');
+  const [displayRole, setDisplayRole] = useState('Mentees');
   const dispatch = useDispatch();
 
   const getAccounts = role => {
@@ -110,11 +110,20 @@ const UserManagement = ({ allMentors, allMentees }) => {
   return (
     <>
       <h2>Manage Users</h2>
-      <Switch
-        checkedChildren={`${displayRole}`}
-        unCheckedChildren={`${displayRole}`}
+      <Tabs
+        type="card"
+        items={[
+          {
+            key: '1',
+            label: 'Mentees',
+          },
+          {
+            key: '2',
+            label: 'Mentors',
+          },
+        ]}
+        defaultActiveKey="1"
         onChange={() => handleChange()}
-        defaultChecked
       />
       <Table
         columns={columns}

--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -9,7 +9,7 @@ const UserManagement = ({ allMentors, allMentees }) => {
   const [userShow, setUserShow] = useState(false);
   const [matchShow, setMatchShow] = useState(false);
   const [user, setUser] = useState('');
-  const [displayRole, setDisplayRole] = useState('Mentees');
+  const [displayRole, setDisplayRole] = useState('Mentors');
   const dispatch = useDispatch();
 
   const getAccounts = role => {

--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -54,25 +54,6 @@ const UserManagement = ({ allMentors, allMentees }) => {
       title: 'Role',
       dataIndex: 'role',
       key: 'role',
-      filters: [
-        {
-          text: 'superAdmin',
-          value: 'superAdmin',
-        },
-        {
-          text: 'admin',
-          value: 'admin',
-        },
-        {
-          text: 'mentor',
-          value: 'mentor',
-        },
-        {
-          text: 'mentee',
-          value: 'mentee',
-        },
-      ],
-      onFilter: (value, record) => record.role.includes(value),
     },
     {
       title: 'Matches',

--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { getAllUsers } from '../../../state/actions/allUsers/getAllUsers';
 import { useDispatch, connect } from 'react-redux';
-import { Table, Button, Switch } from 'antd';
+import { Table, Button, Switch, Tabs } from 'antd';
 import UserModal from './UserModal';
 import MatchingModal from '../MentorMenteeMatching/MatchingModal';
 

--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -123,6 +123,7 @@ const UserManagement = ({ allMentors, allMentees }) => {
           },
         ]}
         defaultActiveKey="1"
+        size="large"
         onChange={() => handleChange()}
       />
       <Table

--- a/src/index.js
+++ b/src/index.js
@@ -102,11 +102,11 @@ function App() {
           allowRoles={[1, 2, 3, 4, 5]}
           component={Profile}
         />
-        {/* <PrivateRoute
+        <PrivateRoute
           path="/users"
           allowRoles={[1, 2, 5]}
           component={UserManagement}
-        /> */}
+        />
         <PrivateRoute
           path="/mentees"
           allowRoles={[1, 2, 3, 5]}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -94,10 +94,12 @@ div.row2 .modalBtn:visited {
 }
 .nameLink {
   color: #d6d6d6;
+  text-decoration: underline;
 }
 .nameLink:hover {
   cursor: pointer;
   color: #257ddc;
+  text-decoration: none;
 }
 .MatchingModal {
   width: 100%;


### PR DESCRIPTION
## Description

The toggle to enable admins to see mentees and mentors was using a Switch toggle. I updated the toggle to Ant Design tabs as per the desired design instructions. There are 2 tabs only - Mentees and Mentors. The Mentees tab is the default tab on page load. Removed column filters for Roles column on the table displayed for both mentee and mentor views. I also updated the table links for the Name column to be more obvious as users were unable to clearly see that links are clickable without hovering over name. I added an underline by default for those links. Hover remains unlined and blue.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
