### PR TITLE
UD-308 Upon completing an application the button on the page leads to 404

### DIFF
--- a/src/components/pages/RoleApply/Applications/AppSuccess.js
+++ b/src/components/pages/RoleApply/Applications/AppSuccess.js
@@ -7,7 +7,7 @@ const { Title } = Typography;
 export default function AppSuccess() {
   let history = useHistory();
   const handleHomeClick = () => {
-    history.push('/landing');
+    history.push('/');
   };
 
   return (


### PR DESCRIPTION
## Description

When submitting a mentor/mentee application form, a success page with a 'home' button is shown. When the button is clicked it sends the user to a 404 page. The user should be directed to the default landing page. I fixed the link for the button after a successful application submission to redirect to the landing page.

Fixes 404 not found redirect issue

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
