### PR TITLE
UD-309-Mentees-and-Mentors-tabs-are-the-opposite

### DIFF
--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -9,7 +9,7 @@ const UserManagement = ({ allMentors, allMentees }) => {
   const [userShow, setUserShow] = useState(false);
   const [matchShow, setMatchShow] = useState(false);
   const [user, setUser] = useState('');
-  const [displayRole, setDisplayRole] = useState('Mentors');
+  const [displayRole, setDisplayRole] = useState('Mentees');
   const dispatch = useDispatch();
 
   const getAccounts = role => {


### PR DESCRIPTION
## Description

I changed the default useState back to 'Mentors' in response to a comment on my last PR. Upon further examination, I have returned useState default back to 'Mentees' for [displayRole, setDisplayRole] as changing it to 'Mentors' causes app to show mentors when on Mentee tab and mentees when on Mentor tab.

Fixes mismatched display

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
