### PR TITLE
Rejected/Inactive Application Page

### DIFF
--- a/src/components/pages/Dashboard/Dashboard.js
+++ b/src/components/pages/Dashboard/Dashboard.js
@@ -6,33 +6,27 @@ import MenteeMentorDashboard from '../MenteeMentorDashboard/MenteeMentorDashboar
 import Mentee from '../RoleApply/Applications/Mentee';
 import Mentor from '../RoleApply/Applications/Mentor';
 import AppPending from '../RoleApply/Applications/AppPending';
+import AppRejected from '../RoleApply/Applications/AppRejected';
 import LoadingComponent from '../../common/LoadingComponent';
 
-const Dashboard = props => {
+const Dashboard = ({ currentUser }) => {
   const { user } = useAuth0();
-  const { currentUser } = props;
-  /*
-   ** Following 2 lines check for user_metadata from Auth0 - if this data
-   ** exists, current user is new and needs to fill out form, so we
-   ** push them there.
-   */
-  // const newUser =
-  //   user[`${process.env.REACT_APP_AUTH0_IDTOKEN_IDENTIFIER}/newUser`];
-  // const newUserRole =
-  //   user[`${process.env.REACT_APP_AUTH0_IDTOKEN_IDENTIFIER}/role`];
-  // console.log(newUser);
-  // console.log(newUserRole);
-  if (currentUser.role === 'admin') {
+
+  const { role, tempProfile, validate_status, is_active } = currentUser;
+
+  if (role === 'admin') {
     return <Applications />;
-  } else if (currentUser.validate_status === 'pending') {
+  } else if (validate_status === 'pending') {
     return <AppPending />;
-  } else if (!currentUser.tempProfile && currentUser.role === 'mentor') {
+  } else if (validate_status === 'rejected' || is_active === false) {
+    return <AppRejected />;
+  } else if (!tempProfile && role === 'mentor') {
     return <MenteeMentorDashboard />;
-  } else if (!currentUser.tempProfile && currentUser.role === 'mentee') {
+  } else if (!tempProfile && role === 'mentee') {
     return <MenteeMentorDashboard />;
-  } else if (currentUser.tempProfile && currentUser.role === 'mentor') {
+  } else if (tempProfile && role === 'mentor') {
     return <Mentor />;
-  } else if (currentUser.tempProfile && currentUser.role === 'mentee') {
+  } else if (tempProfile && role === 'mentee') {
     return <Mentee />;
   } else {
     return <LoadingComponent />;

--- a/src/components/pages/RoleApply/Applications/AppPending.js
+++ b/src/components/pages/RoleApply/Applications/AppPending.js
@@ -15,7 +15,7 @@ function AppPending(props) {
 
   return (
     <>
-      <Row align="center" gutter={[16, 16]} style={{ marginTop: '5vh' }}>
+      <Row align="center" gutter={[16, 16]} style={{ marginTop: '35vh' }}>
         <Col span={24} align="middle">
           <Title level={2}>Pending Application</Title>
         </Col>

--- a/src/components/pages/RoleApply/Applications/AppRejected.js
+++ b/src/components/pages/RoleApply/Applications/AppRejected.js
@@ -1,25 +1,26 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import { Col, Row, Typography, Button } from 'antd';
 import { useHistory } from 'react-router-dom';
 
 const { Title } = Typography;
 
-export default function AppSuccess() {
+function AppRejected(props) {
   let history = useHistory();
   const handleHomeClick = () => {
     history.push('/');
   };
 
+  let { currentUser } = props;
+
   return (
     <>
       <Row align="center" gutter={[16, 16]} style={{ marginTop: '35vh' }}>
         <Col span={24} align="middle">
-          <Title level={2}>Thank you!</Title>
-        </Col>
-        <Col span={24} align="middle">
           <Typography>
-            Your application has been received, keep an eye on your email, as
-            we'll email you if your application has been approved.
+            You are not currently an active member of Underdog Devs. If you
+            believe you have reached this page in error email{' '}
+            <a href="mailto:underdogdevs@gmail.com">underdogdevs@gmail.com</a>
           </Typography>
         </Col>
         <Button onClick={handleHomeClick}>Home</Button>
@@ -27,3 +28,9 @@ export default function AppSuccess() {
     </>
   );
 }
+
+const mapStateToProps = state => {
+  return { currentUser: state.user.currentUser };
+};
+
+export default connect(mapStateToProps)(AppRejected);


### PR DESCRIPTION
## Description

This pull request adds a page that rejected and inactive users will see that contains instructions for getting in touch with Underdog Devs if the user has reached this page in error.

It also adjusts the messaging position on the `AppPending` and `AppSuccess` pages to match mockups closer, shifting the message down from the top of the page to the center of the browser view.

Finally, the `Dashboard.js` code has been simplified, deconstructing `currentUser` from the props, assigning the necessary values from that user's info to variables, and then using those variables in our checks, rather than repeating `currentUser.(...)` ad nauseam.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
