### PR TITLE
Restore "Add as Match" functionality

### DIFF
--- a/src/state/actions/allUsers/setAllUsers.js
+++ b/src/state/actions/allUsers/setAllUsers.js
@@ -14,6 +14,7 @@ export const setAllUsers = (list, role) => {
           <Tag color={'orange'}>No Matches</Tag>
         ),
       role: role === 'mentor' ? 'Mentor' : 'Mentee',
+      matches: row.matches === undefined ? [] : row.matches,
       ...row,
     };
   });


### PR DESCRIPTION
## Description

This PR restores our ability to actually add matches for our users from the `MatchingModal` by updating the `setAllUsers` Redux function to ensure each user has a `matches` value. If a user comes through that has no matches yet, they don't have a `matches` value in their data, which our `MatchingModal` needs in order to also update local state when a match change is made.

By checking to see that the user doesn't have this value yet, we can update their data locally to ensure the `MatchingModal` can complete it's job on user input.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
