### PR TITLE
[BUG] Application breadcrumb navigates to a 404

### DIFF
--- a/src/components/pages/Applications/Applications.js
+++ b/src/components/pages/Applications/Applications.js
@@ -77,7 +77,7 @@ const Applications = () => {
     const timestamp = new Date(previousDate);
     const newConvertedDate = timestamp.toLocaleString();
     if (newConvertedDate === 'Invalid Date') {
-      return new Date().toLocaleString();
+      return '';
     }
     return newConvertedDate;
   };


### PR DESCRIPTION
## Description

This PR addresses the `404 Page Not Found` issue found when a user clicks on the **Apply** breadcrumb. Here I've removed the breadcrumb for the `/apply` page since that page no longer exists, replacing it with a breadcrumb link to the landing page labeled "Home" with a fresh, appropriate icon from the Ant Design Library.

I've also made a quick change to the breadcrumbs to make sure the breadcrumb for the page we're on is visible no matter the theme selected - it will now show in white if in dark mode, and in black if in light mode.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
