### PR TITLE
Add "Dashboard" button to navbar

### DIFF
--- a/src/components/pages/Navbar/Navbar.js
+++ b/src/components/pages/Navbar/Navbar.js
@@ -103,7 +103,7 @@ const Navbar = ({ currentUser, dispatch }) => {
   const accountMenu = <Menu items={menuItems} onClick={handleMenuClick} />;
 
   const reloadLogo = () => {
-    history.push('/dashboard');
+    history.push('/');
     document.location.reload();
   };
 

--- a/src/components/pages/Navbar/NavbarItems.js
+++ b/src/components/pages/Navbar/NavbarItems.js
@@ -1,5 +1,5 @@
 import { useAuth0 } from '@auth0/auth0-react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { connect, useDispatch } from 'react-redux';
 import './Navbar.less';
 import { Menu, Button, Switch } from 'antd';
@@ -12,6 +12,7 @@ const NavbarItems = () => {
   const { loginWithRedirect, logout, isAuthenticated, user } = useAuth0();
   const { push } = useHistory();
   const dispatch = useDispatch();
+  let location = useLocation();
 
   const logoutAuth = () => {
     localStorage.removeItem('AuthToken');
@@ -57,9 +58,20 @@ const NavbarItems = () => {
           Login / Apply
         </Button>
       )}
-
-      {isAuthenticated && (
+      {isAuthenticated && location.pathname !== '/dashboard' ? (
         <>
+          <Button type="primary" onClick={() => push('/dashboard')}>
+            Dashboard
+          </Button>
+          <Button type="primary" onClick={logoutAuth}>
+            Logout
+          </Button>
+        </>
+      ) : (
+        <>
+          <Button type="primary" onClick={() => push('/')}>
+            Home
+          </Button>
           <Button type="primary" onClick={logoutAuth}>
             Logout
           </Button>


### PR DESCRIPTION
## Description

This PR adds some much-needed navigation for authenticated users. Previously, if an authenticated user found themselves on the landing page for any reason - such as leaving the page and returning without logging out - they would have no means of getting back to their dashboard except for adding `/dashboard` to their URL.

Here, I've added a new `Dashboard` button that will push the user to their dashboard when clicked, as well as adding a `Home` button that shows instead when the user is already on the dashboard. Additionally, I've implemented some basic logic that ensures the user only sees the `Dashboard` button if they're **not** already on the Dashboard, and the `Home` button only if they **are** already on the Dashboard.

Finally, I've changed the location clicking the navbar logo brings you to `/`, rather than to `/dashboard`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
