### PR TITLE
Patch/user detail modals

### DIFF
--- a/src/components/pages/MenteeMentorDashboard/MentorModal.jsx
+++ b/src/components/pages/MenteeMentorDashboard/MentorModal.jsx
@@ -45,14 +45,21 @@ const MentorModal = ({ userShow, handleCancel, user }) => {
 
             <div span={24} className="customCol">
               <div className="FieldTitle">Mentorship Topics</div>
-              <p className="FieldValue">
+              <div
+                className="FieldValue"
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'flex-start',
+                }}
+              >
                 {user?.tech_stack.length > 0 &&
                 typeof user?.tech_stack !== String
                   ? user?.tech_stack.map(el => {
-                      return <span> {el} &nbsp; &nbsp;</span>;
+                      return <p> {el} &nbsp; &nbsp;</p>;
                     })
                   : user?.tech_stack}
-              </p>
+              </div>
             </div>
 
             <div span={24} className="customCol">

--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -462,6 +462,7 @@ export const MatchingModal = ({
                             <p
                               onClick={() => {
                                 setCurrentMatch(row);
+                                console.log(row);
                                 setIsMatched(true);
                               }}
                               className="viewLink"

--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -197,6 +197,15 @@ export const MatchingModal = ({
   const [isLoading, setIsLoading] = useState(false);
   const dispatch = useDispatch();
 
+  const convertDate = previousDate => {
+    const timestamp = new Date(previousDate);
+    const newConvertedDate = timestamp.toLocaleString();
+    if (newConvertedDate === 'Invalid Date') {
+      return '';
+    }
+    return newConvertedDate;
+  };
+
   async function getUserMatches(idArr, role) {
     setUserMatches(null);
     if (idArr) {
@@ -531,7 +540,9 @@ export const MatchingModal = ({
                   ) : (
                     <div className="updated">
                       {currentMatch.updated_at ? (
-                        <span>Updated: {currentMatch.updated_at}</span>
+                        <span>
+                          Updated: {convertDate(currentMatch.updated_at)}
+                        </span>
                       ) : null}
                       <Button
                         className="ant-btn-secondary"

--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -648,16 +648,34 @@ export const MatchingModal = ({
                   >
                     Mentorship Topics
                   </div>
-                  <p
+                  <div
                     className="FieldValue"
                     style={
                       themeRedux === 'dark'
-                        ? { backgroundColor: '#303030' }
-                        : { backgroundColor: '#FFFFFF' }
+                        ? {
+                            backgroundColor: '#303030',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'flex-start',
+                          }
+                        : {
+                            backgroundColor: '#FFFFFF',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'flex-start',
+                          }
                     }
                   >
-                    {currentMatch.tech_stack}
-                  </p>
+                    {currentMatch?.tech_stack ? (
+                      typeof currentMatch.tech_stack === typeof '' ? (
+                        <p>{currentMatch?.tech_stack}</p>
+                      ) : (
+                        currentMatch?.tech_stack.map((stack, idx) => {
+                          return <p key={idx}>{`${stack}`}</p>;
+                        })
+                      )
+                    ) : null}
+                  </div>
                 </div>
                 <div span={24} className="customCol">
                   <div

--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -481,7 +481,6 @@ export const MatchingModal = ({
                             <p
                               onClick={() => {
                                 setCurrentMatch(row);
-                                console.log(row);
                                 setIsMatched(true);
                               }}
                               className="viewLink"

--- a/src/components/pages/UserManagement/UserManagement.js
+++ b/src/components/pages/UserManagement/UserManagement.js
@@ -421,8 +421,18 @@ export const MatchingModal = ({
                     className="FieldValue"
                     style={
                       themeRedux === 'dark'
-                        ? { backgroundColor: '#303030' }
-                        : { backgroundColor: '#FFFFFF' }
+                        ? {
+                            backgroundColor: '#303030',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'flex-start',
+                          }
+                        : {
+                            backgroundColor: '#FFFFFF',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'flex-start',
+                          }
                     }
                   >
                     {typeof user?.tech_stack === typeof '' ? (

--- a/src/components/pages/UserManagement/UserModal.jsx
+++ b/src/components/pages/UserManagement/UserModal.jsx
@@ -73,29 +73,28 @@ const UserModal = ({ userShow, handleCancel, user }) => {
           </div>
           <div span={24} className="customCol">
             <div className="FieldTitle">Mentorship Topics</div>
-            <p className="FieldValue">
+            <div
+              className="FieldValue"
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'flex-start',
+              }}
+            >
               {user?.tech_stack ? (
                 typeof user.tech_stack === typeof '' ? (
-                  <p>&nbsp; {user?.tech_stack} &nbsp;</p>
+                  <p>{user?.tech_stack}</p>
                 ) : (
                   user?.tech_stack.map((stack, idx) => {
-                    return <p key={idx}> &nbsp; {`${stack}`} &nbsp;</p>;
+                    return <p key={idx}>{`${stack}`}</p>;
                   })
                 )
               ) : null}
-            </p>
+            </div>
           </div>
           <div span={24} className="customCol">
             <div className="FieldTitle">Commit?</div>
             <p className="FieldValue">{user?.commitment ? 'Yes' : 'No'}</p>
-          </div>
-          <div span={24} className="customCol">
-            <div className="FieldTitle">Hear about UD?</div>
-            <p className="FieldValue">{user?.referred_by}</p>
-          </div>
-          <div span={24} className="customCol">
-            <div className="FieldTitle">Anything else</div>
-            <p className="FieldValue">{user?.other_info}</p>
           </div>
         </div>
       </Modal>

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -143,7 +143,6 @@ div.row2 .modalBtn:visited {
   padding: 20px 20px !important;
   margin-bottom: 0px !important;
 }
-
 .FieldValue p {
   display: center;
 }
@@ -209,8 +208,9 @@ div.row2 .modalBtn:visited {
   display: flex;
   flex-direction: column;
   padding: 20px;
-  justify-content: space-between;
+  justify-content: flex-start;
   width: 50%;
+  height: 50%;
 }
 .UserModal .matchingUserTable .customCol {
   width: 100%;


### PR DESCRIPTION
## Description

This PR makes adjustments to various user detail views within the `Applications` and `User Management` components. Previously, users with multiple "Mentorship Topics" had their list separated by spaces, leaving them to be displayed in a row. This fix applies Flexbox to display these elements in column format with space between them, enhancing their readability considerably.

While working on this I turned up a new bug: when a user has a significantly large number of suggested matches it would cause the `currentMatch` display to the right to attempt to spread to match the length of that list. This has been fixed by adjusting the `justify-content` Flexbox properties for that content and giving it a set `height` - now `currentMatch` displays consistently regardless of user type/length of suggested matches list.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
