### PR TITLE
[BUG] Show nav buttons only to logged in users

### DIFF
--- a/src/components/pages/Navbar/NavbarItems.js
+++ b/src/components/pages/Navbar/NavbarItems.js
@@ -58,24 +58,20 @@ const NavbarItems = () => {
           Login / Apply
         </Button>
       )}
-      {isAuthenticated && location.pathname !== '/dashboard' ? (
-        <>
-          <Button type="primary" onClick={() => push('/dashboard')}>
-            Dashboard
-          </Button>
-          <Button type="primary" onClick={logoutAuth}>
-            Logout
-          </Button>
-        </>
-      ) : (
-        <>
-          <Button type="primary" onClick={() => push('/')}>
-            Home
-          </Button>
-          <Button type="primary" onClick={logoutAuth}>
-            Logout
-          </Button>
-        </>
+      {isAuthenticated && location.pathname !== '/dashboard' && (
+        <Button type="primary" onClick={() => push('/dashboard')}>
+          Dashboard
+        </Button>
+      )}
+      {isAuthenticated && location.pathname === '/dashboard' && (
+        <Button type="primary" onClick={() => push('/')}>
+          Home
+        </Button>
+      )}
+      {isAuthenticated && (
+        <Button type="primary" onClick={logoutAuth}>
+          Logout
+        </Button>
       )}
     </Menu>
   );


### PR DESCRIPTION
## Description

This PR polishes the logic that shows and hides navbar buttons (Logout, Home, and Dashboard) based on user auth status. We now only show the Home button when a user is authenticated and viewing `/dashboard`, the Dashboard button when a user is authenticated and viewing the landing page, and the Logout button only when the user is authenticated.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
